### PR TITLE
fix: /model 명령어 즉시 반영 및 로딩 hang 해결

### DIFF
--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -195,6 +195,8 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
       }
 
       // /model <name> — optimistic update via sessions.patch (same path as Settings UI)
+      // Don't use sendMessage — gateway may not stream a response for slash commands,
+      // which would leave streaming=true and the UI stuck in loading state.
       if (trimmed.startsWith("/model ")) {
         const modelArg = text.trim().slice(7).trim();
         if (modelArg && client && isConnected) {
@@ -203,7 +205,6 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
           } catch (err) {
             console.error("[AWF] model patch error:", err);
           }
-          sendMessage(text);
           refreshSessions();
         }
         return;


### PR DESCRIPTION
## Summary
- `/model <name>` 실행 시 `sessions.patch`를 직접 호출하여 모델 즉시 변경 (Settings UI와 동일 경로)
- `sendMessage` 제거 — 게이트웨이가 slash command에 streaming 응답을 보내지 않아 `streaming=true` 상태로 UI가 영원히 로딩되는 문제 해결
- `setTimeout` 폴링 제거, `refreshSessions()` 즉시 호출로 헤더 뱃지 즉시 반영

## Test plan
- [ ] `/model opus` 입력 → 헤더 뱃지가 즉시 변경, 로딩 없음
- [ ] 스트리밍 중 `/model sonnet` → 뱃지 즉시 반영, 스트리밍 영향 없음
- [ ] `/model asdfgh` (잘못된 모델명) → 에러 catch, 기존 모델 유지
- [ ] `/model` (인자 없음) → 기존 sendMessage 경로 동작 유지
- [ ] Settings UI 드롭다운 모델 변경 정상 동작 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)