### PR TITLE
fix: /model 변경 시 UI에 즉시 반영되지 않는 버그 수정

### DIFF
--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -61,7 +61,7 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
 
   const { messages, streaming, loading, sendMessage, addUserMessage, cancelQueued, abort } = useChat(effectiveSessionKey);
   const { agents } = useAgents();
-  const { sessions, loading: sessionsLoading, refresh: refreshSessions } = useSessions();
+  const { sessions, loading: sessionsLoading, refresh: refreshSessions, patchSession } = useSessions();
 
   const { attachments, addFiles, removeAttachment, clearAttachments } = useFileAttachments();
 
@@ -200,6 +200,10 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
       if (trimmed.startsWith("/model ")) {
         const modelArg = text.trim().slice(7).trim();
         if (modelArg && client && isConnected) {
+          // Optimistic: update UI immediately before gateway roundtrip
+          if (effectiveSessionKey) {
+            patchSession(effectiveSessionKey, { model: modelArg });
+          }
           try {
             await client.request("sessions.patch", { key: effectiveSessionKey, model: modelArg });
           } catch (err) {

--- a/src/lib/gateway/hooks.tsx
+++ b/src/lib/gateway/hooks.tsx
@@ -164,7 +164,12 @@ export function useSessions() {
     return () => clearInterval(id);
   }, [state, refreshThrottled]);
 
-  return { sessions, loading, refresh: fetchSessions };
+  // Optimistic local patch — update a session field immediately without waiting for gateway refresh
+  const patchSession = useCallback((key: string, patch: Record<string, unknown>) => {
+    setSessions((prev) => prev.map((s) => (s.key === key ? { ...s, ...patch } : s)));
+  }, []);
+
+  return { sessions, loading, refresh: fetchSessions, patchSession };
 }
 
 // --- Helpers ---


### PR DESCRIPTION
## Summary
- `/model` 명령어로 모델 변경 후 UI 하단 툴바에 이전 모델명이 계속 표시되는 버그 수정
- `useSessions` hook에 `patchSession` 함수를 추가하여 optimistic update 지원
- gateway 요청 전에 로컬 상태를 먼저 업데이트하여 즉시 반영

Closes #11

## Test plan
- [ ] `/model opus` 실행 후 하단 툴바에 `opus`가 즉시 표시되는지 확인
- [ ] 페이지 새로고침 후에도 변경된 모델명이 유지되는지 확인
- [ ] `/model` (인자 없음) 실행 시 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)