### PR TITLE
fix: 테이블이 메시지 버블 박스를 벗어나는 overflow 수정

### DIFF
--- a/src/components/chat/markdown-renderer.tsx
+++ b/src/components/chat/markdown-renderer.tsx
@@ -249,6 +249,13 @@ const components: Partial<Components> = {
     }
     return <a>{children}</a>;
   },
+  table({ children }) {
+    return (
+      <div className="table-wrapper">
+        <table>{children}</table>
+      </div>
+    );
+  },
 };
 
 // ---- Media file type detection ----

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -129,6 +129,7 @@ body {
   line-height: 1.5;
   overflow-wrap: break-word;
   word-break: break-word;
+  overflow-x: hidden;
 }
 
 .prose p {
@@ -183,6 +184,7 @@ body {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   margin: 0.75em 0;
+  max-width: 100%;
 }
 
 .prose .table-wrapper table {


### PR DESCRIPTION
## Summary

마크다운 테이블이 메시지 버블 경계를 벗어나 렌더링되는 버그 수정.

Closes #16

## Changes

### `markdown-renderer.tsx`
- `ReactMarkdown` components에 `table` 커스텀 렌더러 추가
- `<table>`을 `<div className="table-wrapper">`로 감싸 기존 CSS(`overflow-x: auto`)가 적용되도록 함

### `globals.css`
- `.prose`에 `overflow-x: hidden` 추가 — 테이블 등 넓은 콘텐츠가 버블 밖으로 삐져나오는 것 방지
- `.table-wrapper`에 `max-width: 100%` 추가 — 스크롤 컨테이너 자체가 부모 폭을 초과하지 않도록

## Before / After

- **Before:** 테이블 border가 메시지 박스와 어긋남 (셀이 버블 밖으로 넘침)
- **After:** 테이블이 버블 안에 완전히 포함, 넓은 테이블은 가로 스크롤로 처리