### PR TITLE
fix: 스트리밍 중단이 제대로 전달되지 않는 버그 수정

### DIFF
--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -99,6 +99,10 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
         e.preventDefault();
         setNewSessionPickerOpen(true);
       }
+      if (matchesShortcutId(e, "abort-stream") && streaming) {
+        e.preventDefault();
+        abort();
+      }
       // Tab: cycle forward through session tabs / Shift+Tab: cycle backward
       if (e.key === "Tab" && !e.ctrlKey && !e.metaKey && !e.altKey && agentSessions.length > 1) {
         // Only intercept when focus is on textarea (chat input) or panel root
@@ -114,7 +118,7 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isActive, agentId, setSessionKey, refreshSessions, agentSessions, effectiveSessionKey]);
+  }, [isActive, agentId, setSessionKey, refreshSessions, agentSessions, effectiveSessionKey, streaming, abort]);
 
   // Restore focus to this panel's textarea
   const refocusPanel = useCallback(() => {

--- a/src/lib/gateway/hooks.tsx
+++ b/src/lib/gateway/hooks.tsx
@@ -269,6 +269,7 @@ export function useChat(sessionKey?: string) {
     content: string;
     toolCalls: Map<string, ToolCall>;
   } | null>(null);
+  const runIdRef = useRef<string | null>(null);
   const sessionKeyRef = useRef(sessionKey);
 
   // Queue storage key (must be before loadHistory which references it)
@@ -528,6 +529,7 @@ export function useChat(sessionKey?: string) {
       } else if (stream === "lifecycle" && data?.phase === "start") {
         // lifecycle start
           setStreaming(true);
+          runIdRef.current = (raw.runId as string) ?? null;
           setAgentStatusDebug({ phase: "thinking" });
       } else if (stream === "lifecycle" && data?.phase === "end") {
         // lifecycle end = done
@@ -728,10 +730,22 @@ export function useChat(sessionKey?: string) {
   const abort = useCallback(async () => {
     if (!client || state !== "connected") return;
     try {
-      await client.request("chat.abort", { sessionKey });
-    } catch {
-      // silently fail
+      await client.request("chat.abort", {
+        sessionKey,
+        runId: runIdRef.current ?? undefined,
+      });
+    } catch (err) {
+      console.warn("[AWF] chat.abort failed:", String(err));
     }
+    // 부분 메시지 마무리
+    if (streamBuf.current) {
+      const abortedId = streamBuf.current.id;
+      setMessages((prev) =>
+        prev.map((m) => m.id === abortedId ? { ...m, streaming: false } : m)
+      );
+      streamBuf.current = null;
+    }
+    runIdRef.current = null;
     setStreaming(false);
     setAgentStatusDebug({ phase: "idle" });
   }, [client, state, sessionKey]);


### PR DESCRIPTION
## Summary
- runId 추적 및 `chat.abort`에 전달하여 정확한 run 중단
- abort 시 `streamBuf` 정리로 부분 메시지 마무리
- abort 에러 로깅 추가 (silent fail → `console.warn`)
- Ctrl+C 단축키를 `abort-stream`에 연결

Closes #7

## Test plan
- [x] `pnpm vitest run` — 114 tests passed
- [x] `pnpm build` — 빌드 성공
- [x] 수동 테스트: Stop 버튼, /stop 명령, Ctrl+C 모두 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)