### PR TITLE
fix: 내용 작성 중 스크롤이 작동하지 않는 이슈 (#6)

### DIFF
--- a/src/__tests__/scroll-behavior.test.ts
+++ b/src/__tests__/scroll-behavior.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+
+// ============================================================
+// Pure function replicas for testing scroll behavior logic (#6)
+// ============================================================
+
+/**
+ * Replica of message-list.tsx handleScroll logic (L155-161)
+ * Determines if user is "at bottom" of scroll container
+ */
+function isAtBottom(scrollHeight: number, scrollTop: number, clientHeight: number, threshold = 80): boolean {
+  return scrollHeight - scrollTop - clientHeight < threshold;
+}
+
+/**
+ * Simulates what happens when container height changes (e.g. textarea resize)
+ * WITHOUT ResizeObserver — the bug scenario
+ */
+function simulateContainerResize(
+  scrollHeight: number,
+  scrollTop: number,
+  oldClientHeight: number,
+  newClientHeight: number,
+  threshold = 80,
+): { wasAtBottom: boolean; isStillAtBottom: boolean } {
+  const wasAtBottom = isAtBottom(scrollHeight, scrollTop, oldClientHeight, threshold);
+  // After resize, scrollTop stays the same but clientHeight changes
+  const isStillAtBottom = isAtBottom(scrollHeight, scrollTop, newClientHeight, threshold);
+  return { wasAtBottom, isStillAtBottom };
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("isAtBottom — 스크롤 위치 판정", () => {
+  it("스크롤이 최하단이면 true", () => {
+    // scrollHeight=1000, scrollTop=700, clientHeight=300 → gap=0
+    expect(isAtBottom(1000, 700, 300)).toBe(true);
+  });
+
+  it("최하단에서 80px 이내이면 true", () => {
+    // scrollHeight=1000, scrollTop=650, clientHeight=300 → gap=50
+    expect(isAtBottom(1000, 650, 300)).toBe(true);
+  });
+
+  it("최하단에서 80px 이상이면 false", () => {
+    // scrollHeight=1000, scrollTop=500, clientHeight=300 → gap=200
+    expect(isAtBottom(1000, 500, 300)).toBe(false);
+  });
+
+  it("컨테이너와 콘텐츠 크기가 같으면 true (스크롤 불필요)", () => {
+    // scrollHeight=300, scrollTop=0, clientHeight=300 → gap=0
+    expect(isAtBottom(300, 0, 300)).toBe(true);
+  });
+});
+
+describe("BUG: textarea 리사이즈 시 스크롤 상태 변화", () => {
+  it("textarea 확장으로 clientHeight 감소 → 하단에서 이탈", () => {
+    // 사용자가 하단에 있는 상태 (gap=0)
+    // scrollHeight=2000, scrollTop=1500, clientHeight=500
+    const result = simulateContainerResize(2000, 1500, 500, 400);
+    expect(result.wasAtBottom).toBe(true);
+    // textarea가 확장되어 clientHeight가 500→400으로 줄어듦
+    // gap = 2000 - 1500 - 400 = 100 > 80 → 더 이상 하단이 아님!
+    expect(result.isStillAtBottom).toBe(false);
+  });
+
+  it("textarea 축소로 clientHeight 증가 → 하단 유지", () => {
+    const result = simulateContainerResize(2000, 1500, 500, 550);
+    expect(result.wasAtBottom).toBe(true);
+    // gap = 2000 - 1500 - 550 = -50 < 80 → 하단 유지
+    expect(result.isStillAtBottom).toBe(true);
+  });
+
+  it("이미 위로 스크롤된 상태에서 리사이즈 → 여전히 위", () => {
+    const result = simulateContainerResize(2000, 500, 500, 400);
+    expect(result.wasAtBottom).toBe(false); // gap=1000
+    expect(result.isStillAtBottom).toBe(false); // gap=1100
+  });
+});
+
+describe("ResizeObserver 적용 후 기대 동작", () => {
+  it("리사이즈 시 isAtBottom 재평가로 올바른 userScrolledUp 설정", () => {
+    // 하단에 있는 상태
+    const scrollHeight = 2000;
+    const scrollTop = 1500;
+    const clientHeight = 500;
+    expect(isAtBottom(scrollHeight, scrollTop, clientHeight)).toBe(true);
+
+    // textarea 확장 → clientHeight 줄어듦
+    const newClientHeight = 400;
+    const atBottomAfterResize = isAtBottom(scrollHeight, scrollTop, newClientHeight);
+    // ResizeObserver가 이 상태를 감지하여 userScrolledUp = !atBottomAfterResize = true
+    expect(atBottomAfterResize).toBe(false);
+    // → 자동 스크롤 미발동 (올바른 동작)
+  });
+
+  it("리사이즈 후 하단에 있으면 자동 스크롤 유지", () => {
+    const scrollHeight = 2000;
+    const scrollTop = 1600;
+    const clientHeight = 500;
+    expect(isAtBottom(scrollHeight, scrollTop, clientHeight)).toBe(true);
+
+    // 약간의 리사이즈 → 여전히 하단
+    const newClientHeight = 450;
+    const atBottomAfterResize = isAtBottom(scrollHeight, scrollTop, newClientHeight);
+    expect(atBottomAfterResize).toBe(true);
+    // → 자동 스크롤 유지 (올바른 동작)
+  });
+});
+
+describe("모바일 키보드 시나리오", () => {
+  it("키보드 등장으로 컨테이너 크게 축소 → 하단 이탈", () => {
+    // 키보드가 300px 차지 → clientHeight 800→500
+    const result = simulateContainerResize(3000, 2200, 800, 500);
+    expect(result.wasAtBottom).toBe(true); // gap=0
+    expect(result.isStillAtBottom).toBe(false); // gap=300
+  });
+
+  it("키보드 사라짐으로 컨테이너 확장 → 하단 복귀", () => {
+    // clientHeight 500→800
+    const result = simulateContainerResize(3000, 2200, 500, 800);
+    expect(result.wasAtBottom).toBe(false); // gap=300
+    expect(result.isStillAtBottom).toBe(true); // gap=0
+  });
+});
+
+describe("scrollIntoView behavior 검증", () => {
+  it("smooth vs instant 동작 차이 확인 (개념 테스트)", () => {
+    // smooth: 애니메이션 → 스트리밍 중 연속 호출 시 스크롤 파이팅 유발
+    // instant: 즉시 이동 → 스크롤 파이팅 없음
+    // 이 테스트는 동작 의도를 문서화
+    const scrollBehaviors = ["smooth", "instant"] as const;
+    expect(scrollBehaviors).toContain("smooth");
+    expect(scrollBehaviors).toContain("instant");
+    // instant가 스트리밍에 더 적합
+  });
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -5,6 +5,17 @@ import { vi } from "vitest";
 // Mock scrollIntoView
 Element.prototype.scrollIntoView = vi.fn();
 
+// Mock ResizeObserver (not available in jsdom)
+global.ResizeObserver = class ResizeObserver {
+  private callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 // Mock matchMedia for responsive hooks
 Object.defineProperty(window, "matchMedia", {
   writable: true,

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -160,6 +160,19 @@ export function MessageList({
     setUserScrolledUp(!atBottom);
   }, []);
 
+  // Re-evaluate scroll position when container is resized
+  // (e.g. textarea height change, mobile keyboard appear/disappear)
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+      setUserScrolledUp(!atBottom);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   // Auto-scroll only when user is at the bottom
   // Use message count + streaming state as trigger (not full messages array) to reduce jitter
   const msgCount = messages.length;


### PR DESCRIPTION
## 요약
채팅 입력 중 메시지 영역 스크롤이 작동하지 않던 문제 수정.

## 원인
`handleScroll`이 `onScroll` 이벤트에만 반응하여 컨테이너 리사이즈 시 `userScrolledUp` 상태가 갱신되지 않음.

- `useAutosizeTextArea`: 매 키스트로크마다 textarea 높이 변경 → 스크롤 컨테이너 clientHeight 변경
- 모바일 `keyboardHeight`: paddingBottom 변경 → 컨테이너 축소
- 두 경우 모두 `scroll` 이벤트 미발생 → `userScrolledUp` stale

## 수정 내용
1. **`message-list.tsx`**: `ResizeObserver`로 컨테이너 크기 변경 감지 → 스크롤 위치 재평가
2. **`setup.ts`**: jsdom용 `ResizeObserver` mock 추가

## 테스트
- 12개 신규 테스트 (`scroll-behavior.test.ts`)
- 전체 126개 테스트 통과

## 테스트 시나리오
- [ ] 입력 중 메시지 영역 스크롤 가능
- [ ] 여러 줄 입력으로 textarea 높이 변경 시 스크롤 위치 유지
- [ ] 스트리밍 중 위로 스크롤 → 자동 스크롤 미발동
- [ ] 모바일 키보드 나타남/사라짐 시 스크롤 위치 정상

Closes #6