### PR TITLE
feat: Cmd+O 에이전트별 세션 브라우저 복구 (#26)

### DIFF
--- a/src/__tests__/agent-browser.test.ts
+++ b/src/__tests__/agent-browser.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSessionKey,
+  groupSessionsByAgent,
+  sessionDisplayName,
+  type GatewaySession,
+} from "@/lib/gateway/session-utils";
+
+// ============================================================
+// Agent Browser (#26) — TDD tests
+// Tests for grouping, filtering, and display logic
+// ============================================================
+
+function makeSession(key: string, opts: Partial<GatewaySession> = {}): GatewaySession {
+  return {
+    key,
+    updatedAt: Date.now(),
+    ...opts,
+  };
+}
+
+describe("groupSessionsByAgent — 에이전트별 세션 그룹화", () => {
+  it("에이전트별로 세션을 그룹화", () => {
+    const sessions = [
+      makeSession("agent:main:main"),
+      makeSession("agent:main:main:thread:abc"),
+      makeSession("agent:murim:main"),
+      makeSession("agent:mobidic:main"),
+      makeSession("agent:mobidic:main:thread:xyz"),
+    ];
+    const groups = groupSessionsByAgent(sessions);
+
+    expect(groups).toHaveLength(3);
+    const agentIds = groups.map((g) => g.agentId);
+    expect(agentIds).toContain("main");
+    expect(agentIds).toContain("murim");
+    expect(agentIds).toContain("mobidic");
+  });
+
+  it("각 그룹 내 세션이 updatedAt 내림차순 정렬", () => {
+    const sessions = [
+      makeSession("agent:main:main", { updatedAt: 1000 }),
+      makeSession("agent:main:main:thread:a", { updatedAt: 3000 }),
+      makeSession("agent:main:main:thread:b", { updatedAt: 2000 }),
+    ];
+    const groups = groupSessionsByAgent(sessions);
+    const mainGroup = groups.find((g) => g.agentId === "main")!;
+
+    expect(mainGroup.sessions[0].updatedAt).toBe(3000);
+    expect(mainGroup.sessions[1].updatedAt).toBe(2000);
+    expect(mainGroup.sessions[2].updatedAt).toBe(1000);
+  });
+
+  it("그룹 자체도 최신 세션 기준 내림차순 정렬", () => {
+    const sessions = [
+      makeSession("agent:alpha:main", { updatedAt: 1000 }),
+      makeSession("agent:beta:main", { updatedAt: 3000 }),
+      makeSession("agent:gamma:main", { updatedAt: 2000 }),
+    ];
+    const groups = groupSessionsByAgent(sessions);
+
+    expect(groups[0].agentId).toBe("beta");
+    expect(groups[1].agentId).toBe("gamma");
+    expect(groups[2].agentId).toBe("alpha");
+  });
+
+  it("빈 세션 배열 → 빈 그룹", () => {
+    expect(groupSessionsByAgent([])).toHaveLength(0);
+  });
+
+  it("cron/subagent 세션도 올바르게 그룹화", () => {
+    const sessions = [
+      makeSession("agent:main:main"),
+      makeSession("agent:main:cron:daily-check"),
+      makeSession("agent:main:subagent:task-123"),
+    ];
+    const groups = groupSessionsByAgent(sessions);
+    const mainGroup = groups.find((g) => g.agentId === "main")!;
+
+    expect(mainGroup.sessions).toHaveLength(3);
+  });
+});
+
+describe("에이전트 브라우저 필터링 로직", () => {
+  /**
+   * Replica of filtering logic for agent browser:
+   * - Hide cron/subagent by default
+   * - Filter by search query (agent name, session label, key)
+   */
+  function filterSessionsForBrowser(
+    sessions: GatewaySession[],
+    search: string,
+    showSystem = false,
+  ): GatewaySession[] {
+    const q = search.toLowerCase().trim();
+    return sessions.filter((s) => {
+      const parsed = parseSessionKey(s.key);
+
+      // Hide cron/subagent unless explicitly searched or showSystem
+      if (!showSystem && (parsed.type === "cron" || parsed.type === "subagent")) {
+        return false;
+      }
+
+      // No search → show all remaining
+      if (!q) return true;
+
+      // Match against agent, label, key
+      const name = sessionDisplayName(s).toLowerCase();
+      return (
+        name.includes(q) ||
+        s.key.toLowerCase().includes(q) ||
+        parsed.agentId.toLowerCase().includes(q)
+      );
+    });
+  }
+
+  it("기본적으로 cron/subagent 세션 숨김", () => {
+    const sessions = [
+      makeSession("agent:main:main"),
+      makeSession("agent:main:cron:daily"),
+      makeSession("agent:main:subagent:task-1"),
+      makeSession("agent:main:main:thread:abc"),
+    ];
+    const filtered = filterSessionsForBrowser(sessions, "");
+
+    expect(filtered).toHaveLength(2);
+    expect(filtered.every((s) => !s.key.includes("cron") && !s.key.includes("subagent"))).toBe(true);
+  });
+
+  it("showSystem=true이면 cron/subagent도 표시", () => {
+    const sessions = [
+      makeSession("agent:main:main"),
+      makeSession("agent:main:cron:daily"),
+      makeSession("agent:main:subagent:task-1"),
+    ];
+    const filtered = filterSessionsForBrowser(sessions, "", true);
+
+    expect(filtered).toHaveLength(3);
+  });
+
+  it("검색어로 에이전트 이름 필터링", () => {
+    const sessions = [
+      makeSession("agent:main:main"),
+      makeSession("agent:murim:main"),
+      makeSession("agent:mobidic:main"),
+    ];
+    const filtered = filterSessionsForBrowser(sessions, "murim");
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].key).toBe("agent:murim:main");
+  });
+
+  it("검색어로 라벨 필터링", () => {
+    const sessions = [
+      makeSession("agent:main:main:thread:a", { label: "프로젝트 미팅" }),
+      makeSession("agent:main:main:thread:b", { label: "코드 리뷰" }),
+    ];
+    const filtered = filterSessionsForBrowser(sessions, "미팅");
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].label).toBe("프로젝트 미팅");
+  });
+
+  it("빈 검색어 → 전체 표시 (cron/subagent 제외)", () => {
+    const sessions = [
+      makeSession("agent:main:main"),
+      makeSession("agent:murim:main"),
+    ];
+    const filtered = filterSessionsForBrowser(sessions, "");
+
+    expect(filtered).toHaveLength(2);
+  });
+});
+
+describe("parseSessionKey — 에이전트 브라우저용 파싱", () => {
+  it("main 세션 파싱", () => {
+    const parsed = parseSessionKey("agent:main:main");
+    expect(parsed.agentId).toBe("main");
+    expect(parsed.type).toBe("main");
+  });
+
+  it("thread 세션 파싱", () => {
+    const parsed = parseSessionKey("agent:main:main:thread:abc123");
+    expect(parsed.agentId).toBe("main");
+    expect(parsed.type).toBe("thread");
+    expect(parsed.detail).toBe("abc123");
+  });
+
+  it("channel 세션 파싱", () => {
+    const parsed = parseSessionKey("agent:main:telegram:mybot:direct:123456789:thread:001");
+    expect(parsed.agentId).toBe("main");
+    expect(parsed.channel).toBe("telegram");
+  });
+});
+
+describe("Cmd+O 단축키 매칭", () => {
+  // Since matchesShortcut is already tested in shortcuts,
+  // we verify the shortcut ID exists and is correctly defined
+  it("agent-browser 단축키 ID가 shortcuts에 정의됨", async () => {
+    const { DEFAULT_SHORTCUTS } = await import("@/lib/shortcuts");
+    const agentBrowser = DEFAULT_SHORTCUTS.find((s) => s.id === "agent-browser");
+
+    expect(agentBrowser).toBeDefined();
+    expect(agentBrowser!.keys).toMatch(/Cmd\+O|Ctrl\+O/);
+    expect(agentBrowser!.scope).toBe("panel");
+  });
+});

--- a/src/components/chat/agent-browser.tsx
+++ b/src/components/chat/agent-browser.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { createPortal } from "react-dom";
+import { useIsMobile } from "@/lib/hooks/use-mobile";
+import {
+  Search,
+  X,
+  Bot,
+  Hash,
+  Timer,
+  GitBranch,
+  ArrowRight,
+  MessageSquare,
+  ChevronDown,
+  ChevronRight,
+  Command,
+} from "lucide-react";
+import {
+  parseSessionKey,
+  groupSessionsByAgent,
+  sessionDisplayName,
+  type GatewaySession,
+  type SessionGroup,
+} from "@/lib/gateway/session-utils";
+import type { Session } from "@/lib/gateway/protocol";
+
+// ---- Type icon per session type ----
+
+const TYPE_ICONS: Record<string, typeof Bot> = {
+  main: Bot,
+  thread: Hash,
+  cron: Timer,
+  subagent: GitBranch,
+  a2a: ArrowRight,
+};
+
+function SessionTypeIcon({ type, size = 14 }: { type: string; size?: number }) {
+  const Icon = TYPE_ICONS[type] || MessageSquare;
+  return <Icon size={size} className="shrink-0 text-muted-foreground" />;
+}
+
+// ---- Relative time helper ----
+
+function relativeTime(ts?: number): string {
+  if (!ts) return "";
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return "방금";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}분 전`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}시간 전`;
+  return `${Math.floor(diff / 86_400_000)}일 전`;
+}
+
+// ---- Agent color ----
+
+function agentColor(agentId: string): string {
+  let hash = 0;
+  for (let i = 0; i < agentId.length; i++) {
+    hash = (hash * 31 + agentId.charCodeAt(i)) | 0;
+  }
+  const colors = [
+    "border-blue-500/30 text-blue-400 bg-blue-500/10",
+    "border-emerald-500/30 text-emerald-400 bg-emerald-500/10",
+    "border-purple-500/30 text-purple-400 bg-purple-500/10",
+    "border-amber-500/30 text-amber-400 bg-amber-500/10",
+    "border-rose-500/30 text-rose-400 bg-rose-500/10",
+    "border-cyan-500/30 text-cyan-400 bg-cyan-500/10",
+    "border-orange-500/30 text-orange-400 bg-orange-500/10",
+    "border-pink-500/30 text-pink-400 bg-pink-500/10",
+  ];
+  return colors[Math.abs(hash) % colors.length];
+}
+
+// ---- Props ----
+
+interface AgentBrowserProps {
+  sessions: (GatewaySession | Session)[];
+  currentKey?: string;
+  onSelect: (key: string) => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  portalContainer?: HTMLElement | null;
+}
+
+export function AgentBrowser({
+  sessions,
+  currentKey,
+  onSelect,
+  open: controlledOpen,
+  onOpenChange,
+  portalContainer,
+}: AgentBrowserProps) {
+  const isMobile = useIsMobile();
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+  const setOpen = useCallback(
+    (v: boolean) => {
+      if (isControlled) {
+        onOpenChange?.(v);
+      } else {
+        setInternalOpen(v);
+      }
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const [search, setSearch] = useState("");
+  const [collapsedAgents, setCollapsedAgents] = useState<Set<string>>(new Set());
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const isKeyboardNav = useRef(false);
+
+  // Convert to GatewaySession format
+  const gwSessions = useMemo((): GatewaySession[] => {
+    return sessions.map((s) => ({
+      key: s.key,
+      label: "label" in s ? (s as GatewaySession).label : "title" in s ? (s as Session).title : null,
+      displayName: "displayName" in s ? (s as GatewaySession).displayName : "agentName" in s ? (s as Session).agentName : null,
+      channel: "channel" in s ? (s as GatewaySession).channel : undefined,
+      updatedAt: "updatedAt" in s
+        ? typeof s.updatedAt === "number" ? s.updatedAt
+        : typeof s.updatedAt === "string" ? new Date(s.updatedAt).getTime()
+        : undefined : undefined,
+    }));
+  }, [sessions]);
+
+  // Filter & group
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase().trim();
+    return gwSessions.filter((s) => {
+      const parsed = parseSessionKey(s.key);
+      // Hide cron/subagent
+      if (parsed.type === "cron" || parsed.type === "subagent") return false;
+      if (!q) return true;
+      const name = sessionDisplayName(s).toLowerCase();
+      return name.includes(q) || s.key.toLowerCase().includes(q) || parsed.agentId.toLowerCase().includes(q);
+    });
+  }, [gwSessions, search]);
+
+  const groups = useMemo(() => groupSessionsByAgent(filtered), [filtered]);
+
+  // Flat list of selectable items for keyboard nav
+  const flatItems = useMemo(() => {
+    const items: { type: "agent" | "session"; agentId: string; sessionKey?: string }[] = [];
+    for (const group of groups) {
+      items.push({ type: "agent", agentId: group.agentId });
+      if (!collapsedAgents.has(group.agentId)) {
+        for (const s of group.sessions) {
+          items.push({ type: "session", agentId: group.agentId, sessionKey: s.key });
+        }
+      }
+    }
+    return items;
+  }, [groups, collapsedAgents]);
+
+  // Toggle agent collapse
+  const toggleAgent = useCallback((agentId: string) => {
+    setCollapsedAgents((prev) => {
+      const next = new Set(prev);
+      if (next.has(agentId)) next.delete(agentId);
+      else next.add(agentId);
+      return next;
+    });
+  }, []);
+
+  // Reset on open
+  useEffect(() => {
+    if (open) {
+      setSearch("");
+      setSelectedIndex(0);
+      setCollapsedAgents(new Set());
+      setTimeout(() => searchRef.current?.focus(), 16);
+    }
+  }, [open]);
+
+  // Escape key
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [open, setOpen]);
+
+  // Scroll selected into view
+  useEffect(() => {
+    if (!isKeyboardNav.current || !listRef.current) return;
+    const items = listRef.current.querySelectorAll("[data-browser-item]");
+    const target = items[selectedIndex] as HTMLElement | undefined;
+    target?.scrollIntoView({ block: "nearest" });
+    requestAnimationFrame(() => { isKeyboardNav.current = false; });
+  }, [selectedIndex]);
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const total = flatItems.length;
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          isKeyboardNav.current = true;
+          setSelectedIndex((i) => (i + 1) % total);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          isKeyboardNav.current = true;
+          setSelectedIndex((i) => (i - 1 + total) % total);
+          break;
+        case "Enter": {
+          e.preventDefault();
+          const item = flatItems[selectedIndex];
+          if (!item) break;
+          if (item.type === "agent") {
+            toggleAgent(item.agentId);
+          } else if (item.sessionKey) {
+            onSelect(item.sessionKey);
+            setOpen(false);
+          }
+          break;
+        }
+        case "ArrowLeft": {
+          e.preventDefault();
+          const item = flatItems[selectedIndex];
+          if (item?.type === "agent" && !collapsedAgents.has(item.agentId)) {
+            toggleAgent(item.agentId);
+          }
+          break;
+        }
+        case "ArrowRight": {
+          e.preventDefault();
+          const item = flatItems[selectedIndex];
+          if (item?.type === "agent" && collapsedAgents.has(item.agentId)) {
+            toggleAgent(item.agentId);
+          }
+          break;
+        }
+      }
+    },
+    [flatItems, selectedIndex, toggleAgent, collapsedAgents, onSelect, setOpen],
+  );
+
+  if (!open) return null;
+
+  let itemIndex = -1;
+
+  const content = (
+    <div className="fixed inset-0 z-50 flex items-start justify-center pt-[10vh]" onClick={() => setOpen(false)}>
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+
+      {/* Panel */}
+      <div
+        className={`relative z-10 flex max-h-[70vh] w-full flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl ${
+          isMobile ? "mx-3" : "max-w-lg"
+        }`}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Search */}
+        <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+          <Search size={16} className="shrink-0 text-muted-foreground" />
+          <input
+            ref={searchRef}
+            type="text"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            placeholder="에이전트 / 세션 검색..."
+            value={search}
+            onChange={(e) => { setSearch(e.target.value); setSelectedIndex(0); }}
+          />
+          <kbd className="hidden md:inline-flex items-center gap-0.5 rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground">
+            <Command size={10} />O
+          </kbd>
+          <button onClick={() => setOpen(false)} className="rounded p-1 text-muted-foreground hover:text-foreground transition">
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* List */}
+        <div ref={listRef} className="flex-1 overflow-y-auto py-2" style={{ maxHeight: "calc(70vh - 60px)" }}>
+          {groups.length === 0 && (
+            <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+              {search ? "검색 결과가 없습니다" : "세션이 없습니다"}
+            </p>
+          )}
+          {groups.map((group) => {
+            const isCollapsed = collapsedAgents.has(group.agentId);
+            itemIndex++;
+            const agentIdx = itemIndex;
+
+            return (
+              <div key={group.agentId}>
+                {/* Agent header */}
+                <button
+                  data-browser-item
+                  className={`mx-1 flex w-[calc(100%-8px)] items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors ${
+                    selectedIndex === agentIdx
+                      ? "bg-accent text-accent-foreground"
+                      : "hover:bg-muted/50"
+                  }`}
+                  onClick={() => toggleAgent(group.agentId)}
+                  onMouseEnter={() => { if (!isKeyboardNav.current) setSelectedIndex(agentIdx); }}
+                >
+                  {isCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+                  <span className={`inline-flex items-center rounded-md border px-1.5 py-0.5 text-[11px] font-semibold leading-none ${agentColor(group.agentId)}`}>
+                    {group.agentId}
+                  </span>
+                  <span className="text-xs text-muted-foreground ml-auto">
+                    {group.sessions.length}개 세션
+                  </span>
+                </button>
+
+                {/* Sessions */}
+                {!isCollapsed && group.sessions.map((s) => {
+                  itemIndex++;
+                  const idx = itemIndex;
+                  const parsed = parseSessionKey(s.key);
+                  const isCurrent = s.key === currentKey;
+                  const label = sessionDisplayName(s);
+
+                  return (
+                    <button
+                      key={s.key}
+                      data-browser-item
+                      className={`mx-1 flex w-[calc(100%-8px)] items-center gap-3 rounded-lg px-3 py-2 pl-8 text-left transition-colors ${
+                        isCurrent
+                          ? "bg-primary/10 text-primary border border-primary/20"
+                          : selectedIndex === idx
+                            ? "bg-accent text-accent-foreground"
+                            : "hover:bg-muted/50"
+                      }`}
+                      onClick={() => { onSelect(s.key); setOpen(false); }}
+                      onMouseEnter={() => { if (!isKeyboardNav.current) setSelectedIndex(idx); }}
+                    >
+                      <SessionTypeIcon type={parsed.type} />
+                      <div className="flex-1 min-w-0">
+                        <p className="truncate text-sm font-medium">{label}</p>
+                        {s.updatedAt && (
+                          <p className="text-[10px] text-muted-foreground">{relativeTime(s.updatedAt)}</p>
+                        )}
+                      </div>
+                      {parsed.channel && (
+                        <span className="text-[10px] text-muted-foreground rounded bg-muted px-1.5 py-0.5">
+                          {parsed.channel}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+
+  if (portalContainer) return createPortal(content, portalContainer);
+  return content;
+}

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -7,6 +7,7 @@ import { ChatInput } from "./chat-input";
 import { AvatarAgentSelector } from "./avatar-agent-selector";
 import { AgentSelector } from "./agent-selector";
 import { SessionSwitcher } from "./session-switcher";
+import { AgentBrowser } from "./agent-browser";
 import { DropZone, useFileAttachments, attachmentToPayload } from "./file-attachments";
 import { parseSessionKey, sessionDisplayName, type GatewaySession } from "@/lib/gateway/session-utils";
 import { TaskMemo } from "./task-memo";
@@ -66,6 +67,7 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
   const { attachments, addFiles, removeAttachment, clearAttachments } = useFileAttachments();
 
   const [sessionSwitcherOpen, setSessionSwitcherOpen] = useState(false);
+  const [agentBrowserOpen, setAgentBrowserOpen] = useState(false);
   const [newSessionPickerOpen, setNewSessionPickerOpen] = useState(false);
   const [agentManagerOpen, setAgentManagerOpen] = useState(false);
   const [sessionManagerOpen, setSessionManagerOpen] = useState(false);
@@ -94,6 +96,10 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
       if (matchesShortcutId(e, "session-switcher")) {
         e.preventDefault();
         setSessionSwitcherOpen((prev) => !prev);
+      }
+      if (matchesShortcutId(e, "agent-browser")) {
+        e.preventDefault();
+        setAgentBrowserOpen((prev) => !prev);
       }
       if (matchesShortcutId(e, "new-session")) {
         e.preventDefault();
@@ -529,6 +535,14 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
               onReset={handleReset}
               open={sessionSwitcherOpen}
               onOpenChange={setSessionSwitcherOpen}
+              portalContainer={panelRef.current}
+            />
+            <AgentBrowser
+              sessions={sessions as GatewaySession[]}
+              currentKey={sessionKey}
+              onSelect={setSessionKey}
+              open={agentBrowserOpen}
+              onOpenChange={setAgentBrowserOpen}
               portalContainer={panelRef.current}
             />
             <div className="ml-auto flex items-center gap-2">


### PR DESCRIPTION
## 요약
`Cmd+O` 단축키로 에이전트별 세션 브라우저를 여는 기능 복구.

## 원인
`shortcuts.ts`에 `agent-browser` (Cmd+O) 단축키가 정의되어 있었으나, 핸들러와 UI 컴포넌트가 구현되지 않았음.

## 구현 내용
1. **`AgentBrowser`** 컴포넌트 신규 추가 (`agent-browser.tsx`)
   - `groupSessionsByAgent()` 유틸리티 활용 (기존 `session-utils.ts`)
   - 에이전트별 접기/펼치기 (chevron toggle)
   - 에이전트/세션 이름/키 검색
   - 키보드 네비게이션 (↑↓ 이동, Enter 선택/토글, ←→ 접기/펼치기)
   - cron/subagent 세션 기본 숨김
2. **`chat-panel.tsx`**: `matchesShortcutId(e, "agent-browser")" 핸들러 연결

## 테스트
- 14개 신규 테스트 (`agent-browser.test.ts`)
- 전체 128개 테스트 통과

Closes #26