### PR TITLE
fix: #26 Shortcut 시스템 정비 — Cmd+O 미작동 및 미연결 단축키 일괄 수정

### DIFF
--- a/src/__tests__/shortcut-system.test.ts
+++ b/src/__tests__/shortcut-system.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  matchesShortcut,
+  matchesShortcutId,
+  parseKeys,
+  getEffectiveShortcuts,
+  loadCustomBindings,
+  saveCustomBindings,
+  DEFAULT_SHORTCUTS,
+} from "@/lib/shortcuts";
+
+// jsdom userAgent doesn't contain "Mac", so isMac=false in test env.
+// Shortcuts default to Ctrl-based (Windows/Linux) variants.
+// We test against effective shortcuts to be OS-independent.
+const isMacEnv = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+
+// --- Helper: create a KeyboardEvent with specific properties ---
+
+function createKeyboardEvent(
+  key: string,
+  opts: {
+    metaKey?: boolean;
+    ctrlKey?: boolean;
+    shiftKey?: boolean;
+    altKey?: boolean;
+    code?: string;
+    repeat?: boolean;
+  } = {}
+): KeyboardEvent {
+  const code =
+    opts.code ??
+    (key.length === 1 && key >= "a" && key <= "z"
+      ? `Key${key.toUpperCase()}`
+      : key.length === 1 && key >= "0" && key <= "9"
+        ? `Digit${key}`
+        : key === "\\"
+          ? "Backslash"
+          : key === "/"
+            ? "Slash"
+            : key === "Tab"
+              ? "Tab"
+              : `Key${key.toUpperCase()}`);
+
+  return new KeyboardEvent("keydown", {
+    key,
+    code,
+    metaKey: opts.metaKey ?? false,
+    ctrlKey: opts.ctrlKey ?? false,
+    shiftKey: opts.shiftKey ?? false,
+    altKey: opts.altKey ?? false,
+    bubbles: true,
+    cancelable: true,
+  });
+}
+
+// ============================================================
+// 1. parseKeys — key combo 문자열 파싱
+// ============================================================
+
+describe("parseKeys", () => {
+  it("parses Cmd+O correctly", () => {
+    const result = parseKeys("Cmd+O");
+    expect(result).toEqual({ meta: true, ctrl: false, shift: false, alt: false, key: "o" });
+  });
+
+  it("parses Ctrl+1 correctly", () => {
+    const result = parseKeys("Ctrl+1");
+    expect(result).toEqual({ meta: false, ctrl: true, shift: false, alt: false, key: "1" });
+  });
+
+  it("parses Cmd+Ctrl+Shift+S correctly", () => {
+    const result = parseKeys("Cmd+Ctrl+Shift+S");
+    expect(result).toEqual({ meta: true, ctrl: true, shift: true, alt: false, key: "s" });
+  });
+
+  it("parses Cmd+\\ correctly", () => {
+    const result = parseKeys("Cmd+\\");
+    expect(result).toEqual({ meta: true, ctrl: false, shift: false, alt: false, key: "\\" });
+  });
+
+  it("parses Tab (no modifier) correctly", () => {
+    const result = parseKeys("Tab");
+    expect(result).toEqual({ meta: false, ctrl: false, shift: false, alt: false, key: "tab" });
+  });
+
+  it("parses Shift+Tab correctly", () => {
+    const result = parseKeys("Shift+Tab");
+    expect(result).toEqual({ meta: false, ctrl: false, shift: true, alt: false, key: "tab" });
+  });
+});
+
+// ============================================================
+// 2. matchesShortcut — KeyboardEvent와 키 조합 문자열 매칭
+// ============================================================
+
+describe("matchesShortcut", () => {
+  it("matches Cmd+O", () => {
+    const e = createKeyboardEvent("o", { metaKey: true });
+    expect(matchesShortcut(e, "Cmd+O")).toBe(true);
+  });
+
+  it("does not match Cmd+O when Ctrl is pressed instead", () => {
+    const e = createKeyboardEvent("o", { ctrlKey: true });
+    expect(matchesShortcut(e, "Cmd+O")).toBe(false);
+  });
+
+  it("matches Ctrl+1", () => {
+    const e = createKeyboardEvent("1", { ctrlKey: true, code: "Digit1" });
+    expect(matchesShortcut(e, "Ctrl+1")).toBe(true);
+  });
+
+  it("matches Cmd+\\", () => {
+    const e = createKeyboardEvent("\\", { metaKey: true, code: "Backslash" });
+    expect(matchesShortcut(e, "Cmd+\\")).toBe(true);
+  });
+
+  it("matches Tab without modifiers", () => {
+    const e = createKeyboardEvent("Tab", { code: "Tab" });
+    expect(matchesShortcut(e, "Tab")).toBe(true);
+  });
+
+  it("matches Shift+Tab", () => {
+    const e = createKeyboardEvent("Tab", { shiftKey: true, code: "Tab" });
+    expect(matchesShortcut(e, "Shift+Tab")).toBe(true);
+  });
+
+  it("does not match Tab when Shift is also pressed", () => {
+    const e = createKeyboardEvent("Tab", { shiftKey: true, code: "Tab" });
+    expect(matchesShortcut(e, "Tab")).toBe(false);
+  });
+});
+
+// ============================================================
+// 3. matchesShortcutId — 정의된 shortcut ID로 매칭
+// ============================================================
+
+describe("matchesShortcutId", () => {
+  // Helper: use metaKey on Mac, ctrlKey elsewhere (matching how shortcuts.ts resolves)
+  const cmdMod = isMacEnv ? { metaKey: true } : { ctrlKey: true };
+  // For shortcuts that use Ctrl on Mac and Alt on non-Mac
+  const ctrlMod = isMacEnv ? { ctrlKey: true } : { altKey: true };
+
+  it("matches agent-browser (Cmd+O / Ctrl+O)", () => {
+    const e = createKeyboardEvent("o", cmdMod);
+    expect(matchesShortcutId(e, "agent-browser")).toBe(true);
+  });
+
+  it("matches session-switcher (Cmd+K / Ctrl+K)", () => {
+    const e = createKeyboardEvent("k", cmdMod);
+    expect(matchesShortcutId(e, "session-switcher")).toBe(true);
+  });
+
+  it("matches help (Cmd+/ / Ctrl+/)", () => {
+    const e = createKeyboardEvent("/", { ...cmdMod, code: "Slash" });
+    expect(matchesShortcutId(e, "help")).toBe(true);
+  });
+
+  it("matches add-panel (Cmd+\\ / Ctrl+\\)", () => {
+    const e = createKeyboardEvent("\\", { ...cmdMod, code: "Backslash" });
+    expect(matchesShortcutId(e, "add-panel")).toBe(true);
+  });
+
+  it("matches focus-panel-1 (Ctrl+1)", () => {
+    const e = createKeyboardEvent("1", { ctrlKey: true, code: "Digit1" });
+    expect(matchesShortcutId(e, "focus-panel-1")).toBe(true);
+  });
+
+  it("matches focus-panel-5 (Ctrl+5)", () => {
+    const e = createKeyboardEvent("5", { ctrlKey: true, code: "Digit5" });
+    expect(matchesShortcutId(e, "focus-panel-5")).toBe(true);
+  });
+
+  it("matches next-session (Tab)", () => {
+    const e = createKeyboardEvent("Tab", { code: "Tab" });
+    expect(matchesShortcutId(e, "next-session")).toBe(true);
+  });
+
+  it("matches prev-session (Shift+Tab)", () => {
+    const e = createKeyboardEvent("Tab", { shiftKey: true, code: "Tab" });
+    expect(matchesShortcutId(e, "prev-session")).toBe(true);
+  });
+
+  it("returns false for unknown shortcut id", () => {
+    const e = createKeyboardEvent("z", { metaKey: true });
+    expect(matchesShortcutId(e, "nonexistent-shortcut")).toBe(false);
+  });
+});
+
+// ============================================================
+// 4. Custom bindings — 사용자 커스텀 바인딩
+// ============================================================
+
+describe("custom bindings", () => {
+  const STORAGE_KEY = "awf:custom-shortcuts";
+  let store: Record<string, string> = {};
+
+  beforeEach(() => {
+    store = {};
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => { store[key] = value; },
+      removeItem: (key: string) => { delete store[key]; },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loadCustomBindings returns empty when nothing saved", () => {
+    expect(loadCustomBindings()).toEqual({});
+  });
+
+  it("saveCustomBindings + loadCustomBindings roundtrip", () => {
+    const bindings = { "agent-browser": "Cmd+Shift+O", "add-panel": "Cmd+Shift+\\" };
+    saveCustomBindings(bindings);
+    expect(loadCustomBindings()).toEqual(bindings);
+  });
+
+  it("getEffectiveShortcuts applies custom bindings", () => {
+    saveCustomBindings({ "agent-browser": "Cmd+Shift+O" });
+    const effective = getEffectiveShortcuts();
+    const agentBrowser = effective.find((s) => s.id === "agent-browser");
+    expect(agentBrowser?.keys).toBe("Cmd+Shift+O");
+  });
+
+  it("matchesShortcutId respects custom bindings", () => {
+    saveCustomBindings({ "agent-browser": "Cmd+Shift+O" });
+
+    // Original Cmd+O should NOT match anymore
+    const origEvent = createKeyboardEvent("o", { metaKey: true });
+    expect(matchesShortcutId(origEvent, "agent-browser")).toBe(false);
+
+    // New Cmd+Shift+O SHOULD match
+    const newEvent = createKeyboardEvent("o", { metaKey: true, shiftKey: true });
+    expect(matchesShortcutId(newEvent, "agent-browser")).toBe(true);
+  });
+
+  it("non-overridden shortcuts remain at defaults", () => {
+    saveCustomBindings({ "agent-browser": "Cmd+Shift+O" });
+    const effective = getEffectiveShortcuts();
+    const sessionSwitcher = effective.find((s) => s.id === "session-switcher");
+    // Default should be preserved
+    expect(sessionSwitcher?.keys).toMatch(/K/);
+  });
+});
+
+// ============================================================
+// 5. Shortcut definitions — 전체 shortcut 정의 완전성 검증
+// ============================================================
+
+describe("shortcut definitions completeness", () => {
+  const requiredIds = [
+    "help",
+    "add-panel",
+    "focus-left",
+    "focus-right",
+    "swap-panels",
+    "close-panel",
+    "reopen-panel",
+    "new-session",
+    "abort-stream",
+    "next-session",
+    "prev-session",
+    "session-switcher",
+    "agent-browser",
+    "focus-panel-1",
+    "focus-panel-2",
+    "focus-panel-3",
+    "focus-panel-4",
+    "focus-panel-5",
+  ];
+
+  it("all 18 shortcuts are defined in DEFAULT_SHORTCUTS", () => {
+    const definedIds = DEFAULT_SHORTCUTS.map((s) => s.id);
+    for (const id of requiredIds) {
+      expect(definedIds).toContain(id);
+    }
+  });
+
+  it("every shortcut has a non-empty keys string", () => {
+    for (const s of DEFAULT_SHORTCUTS) {
+      expect(s.keys.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every shortcut has a non-empty description", () => {
+    for (const s of DEFAULT_SHORTCUTS) {
+      expect(s.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("no duplicate shortcut ids", () => {
+    const ids = DEFAULT_SHORTCUTS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("no duplicate key combos", () => {
+    const keys = DEFAULT_SHORTCUTS.map((s) => s.keys);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -99,19 +99,23 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
         e.preventDefault();
         setNewSessionPickerOpen(true);
       }
+      if (matchesShortcutId(e, "agent-browser")) {
+        e.preventDefault();
+        setSessionManagerOpen((prev) => !prev);
+      }
       if (matchesShortcutId(e, "abort-stream") && streaming) {
         e.preventDefault();
         abort();
       }
-      // Tab: cycle forward through session tabs / Shift+Tab: cycle backward
-      if (e.key === "Tab" && !e.ctrlKey && !e.metaKey && !e.altKey && agentSessions.length > 1) {
+      // Tab/Shift+Tab: cycle through session tabs (uses matchesShortcutId for custom binding support)
+      if ((matchesShortcutId(e, "next-session") || matchesShortcutId(e, "prev-session")) && agentSessions.length > 1) {
         // Only intercept when focus is on textarea (chat input) or panel root
         const target = e.target as HTMLElement;
         const isInput = target.tagName === "TEXTAREA" || target.closest("[data-chat-panel]");
         if (!isInput) return;
         e.preventDefault();
         const currentIdx = agentSessions.findIndex((s) => s.key === effectiveSessionKey);
-        const delta = e.shiftKey ? -1 : 1;
+        const delta = matchesShortcutId(e, "prev-session") ? -1 : 1;
         const nextIdx = (currentIdx + delta + agentSessions.length) % agentSessions.length;
         setSessionKey(agentSessions[nextIdx].key);
       }

--- a/src/components/chat/chat-view.tsx
+++ b/src/components/chat/chat-view.tsx
@@ -6,7 +6,7 @@ import { useIsMobile } from "@/lib/hooks/use-mobile";
 import { ConnectionStatus } from "./connection-status";
 import { SplitView } from "./split-view";
 import { ShortcutHelpDialog } from "./shortcut-help-dialog";
-import { isShortcutHelp } from "@/lib/shortcuts";
+import { isShortcutHelp, matchesShortcutId } from "@/lib/shortcuts";
 import { Plus, Keyboard, Menu } from "lucide-react";
 
 export function ChatView() {
@@ -28,7 +28,7 @@ export function ChatView() {
       }
       if (e.key === "Escape") setShortcutOpen(false);
 
-      if ((e.metaKey || e.ctrlKey) && e.key === "\\") {
+      if (matchesShortcutId(e, "add-panel")) {
         e.preventDefault();
         (window as any).__awfSplitAddPanel?.();
       }

--- a/src/components/chat/split-view.tsx
+++ b/src/components/chat/split-view.tsx
@@ -232,6 +232,24 @@ export function SplitView() {
       } else if (matchesShortcutId(e, "reopen-panel")) {
         e.preventDefault(); e.stopPropagation();
         reopenLastClosedPanel();
+      } else {
+        // focus-panel-1 through focus-panel-5
+        for (let i = 1; i <= 5; i++) {
+          if (matchesShortcutId(e, `focus-panel-${i}`)) {
+            e.preventDefault(); e.stopPropagation();
+            setState((prev) => {
+              const idx = i - 1;
+              if (idx < 0 || idx >= prev.panels.length) return prev;
+              const targetId = prev.panels[idx].id;
+              requestAnimationFrame(() => {
+                const el = document.querySelector(`[data-panel-id="${targetId}"] textarea`) as HTMLElement | null;
+                el?.focus();
+              });
+              return { ...prev, activePanelId: targetId };
+            });
+            break;
+          }
+        }
       }
     };
     window.addEventListener("keydown", handler);


### PR DESCRIPTION
## 요약
GitHub #26: Cmd+O (agent-browser) 단축키 미작동 해결 + shortcut 시스템 전반 정비

## 변경 사항

### Phase 1 — 미구현 핸들러 연결
- `agent-browser` (Cmd+O) → `SessionManagerPanel` 토글 (`chat-panel.tsx`)
- `focus-panel-1~5` (Ctrl+1~5) → 패널 포커스 전환 (`split-view.tsx`)

### Phase 2 — 하드코딩 정규화
- `add-panel` (Cmd+\\): 하드코딩 → `matchesShortcutId` 전환 (`chat-view.tsx`)
- `next/prev-session` (Tab/Shift+Tab): 하드코딩 → `matchesShortcutId` 전환 (`chat-panel.tsx`)

### 효과
- 전체 18개 shortcut이 `matchesShortcutId()` 기반으로 통일
- localStorage 커스텀 바인딩이 모든 단축키에 적용됨

## 테스트
- 32개 신규 테스트 (`shortcut-system.test.ts`)
- 전체 146 tests 통과, 회귀 없음

## 영향 파일
- `src/components/chat/chat-panel.tsx`
- `src/components/chat/chat-view.tsx`
- `src/components/chat/split-view.tsx`
- `src/__tests__/shortcut-system.test.ts` (신규)

Closes #26