### PR TITLE
feat: #9 Markdown 파일 인라인 미리보기 지원

### DIFF
--- a/src/__tests__/markdown-preview.test.ts
+++ b/src/__tests__/markdown-preview.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getMimeType } from "@/lib/mime-types";
+
+// ============================================================
+// 1. MIME detection for .md files
+// ============================================================
+
+describe("markdown MIME detection", () => {
+  it("getMimeType returns text/markdown for md extension", () => {
+    expect(getMimeType("md")).toBe("text/markdown");
+  });
+
+  it("getMimeType returns text/plain for txt extension", () => {
+    expect(getMimeType("txt")).toBe("text/plain");
+  });
+});
+
+// ============================================================
+// 2. MEDIA: protocol with .md files — URL generation
+// ============================================================
+
+describe("MEDIA: protocol .md file handling", () => {
+  it("generates correct download URL for local .md path", () => {
+    const raw = "/tmp/readme.md";
+    const url = `/api/media?path=${encodeURIComponent(raw)}`;
+    expect(url).toBe("/api/media?path=%2Ftmp%2Freadme.md");
+  });
+
+  it("preserves http URL for remote .md file", () => {
+    const raw = "https://example.com/docs/readme.md";
+    const isHttp = raw.startsWith("http://") || raw.startsWith("https://");
+    expect(isHttp).toBe(true);
+  });
+
+  it("extracts .md extension correctly", () => {
+    const fileName = "PROJECT-README.md";
+    const ext = fileName.split(".").pop()?.toLowerCase() || "";
+    expect(ext).toBe("md");
+    expect(getMimeType(ext)).toBe("text/markdown");
+  });
+});
+
+// ============================================================
+// 3. detectMediaType — .md should be "text" type
+// ============================================================
+
+describe("detectMediaType for markdown files", () => {
+  // Mirror the logic from markdown-renderer.tsx
+  const TEXT_EXTS = ["txt", "md", "log", "json", "yaml", "yml"];
+
+  function detectMediaType(path: string): string {
+    const match = path.match(/\.(\w+)(?:\?|$)/);
+    const ext = match ? match[1].toLowerCase() : "";
+    if (TEXT_EXTS.includes(ext)) return "text";
+    return "other";
+  }
+
+  it("detects .md as text type", () => {
+    expect(detectMediaType("/tmp/readme.md")).toBe("text");
+  });
+
+  it("detects .txt as text type", () => {
+    expect(detectMediaType("/tmp/notes.txt")).toBe("text");
+  });
+
+  it("detects .log as text type", () => {
+    expect(detectMediaType("/var/log/app.log")).toBe("text");
+  });
+
+  it("detects unknown extension as other", () => {
+    expect(detectMediaType("/tmp/binary.dat")).toBe("other");
+  });
+});
+
+// ============================================================
+// 4. isMarkdownFile helper logic
+// ============================================================
+
+describe("isMarkdownFile detection", () => {
+  function isMarkdownFile(fileName: string, mimeType?: string): boolean {
+    if (mimeType === "text/markdown") return true;
+    const ext = fileName.split(".").pop()?.toLowerCase();
+    return ext === "md" || ext === "mdx";
+  }
+
+  it("detects .md by extension", () => {
+    expect(isMarkdownFile("readme.md")).toBe(true);
+  });
+
+  it("detects .mdx by extension", () => {
+    expect(isMarkdownFile("page.mdx")).toBe(true);
+  });
+
+  it("detects by MIME type", () => {
+    expect(isMarkdownFile("file", "text/markdown")).toBe(true);
+  });
+
+  it("rejects non-markdown files", () => {
+    expect(isMarkdownFile("image.png")).toBe(false);
+    expect(isMarkdownFile("doc.pdf")).toBe(false);
+    expect(isMarkdownFile("data.json")).toBe(false);
+  });
+
+  it("rejects text/plain (not markdown)", () => {
+    expect(isMarkdownFile("notes.txt", "text/plain")).toBe(false);
+  });
+});
+
+// ============================================================
+// 5. Markdown content fetch simulation
+// ============================================================
+
+describe("markdown content fetch", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  it("fetches and returns markdown content", async () => {
+    const mdContent = "# Hello\n\nThis is a **bold** paragraph.\n\n- Item 1\n- Item 2";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(mdContent),
+    });
+
+    const res = await fetch("/api/media?path=%2Ftmp%2Freadme.md");
+    expect(res.ok).toBe(true);
+    const text = await res.text();
+    expect(text).toContain("# Hello");
+    expect(text).toContain("**bold**");
+  });
+
+  it("handles fetch failure gracefully", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    });
+
+    const res = await fetch("/api/media?path=%2Ftmp%2Fmissing.md");
+    expect(res.ok).toBe(false);
+  });
+
+  it("handles GFM content (tables, strikethrough)", async () => {
+    const gfmContent = "| Col A | Col B |\n|-------|-------|\n| 1 | 2 |\n\n~~deleted~~\n\n- [x] Done\n- [ ] Todo";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(gfmContent),
+    });
+
+    const res = await fetch("/api/media?path=%2Ftmp%2Ftable.md");
+    const text = await res.text();
+    expect(text).toContain("| Col A |");
+    expect(text).toContain("~~deleted~~");
+    expect(text).toContain("[x] Done");
+  });
+
+  it("handles code blocks", async () => {
+    const codeContent = "```typescript\nconst x: number = 42;\n```";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(codeContent),
+    });
+
+    const text = await (await fetch("/api/media?path=%2Ftmp%2Fcode.md")).text();
+    expect(text).toContain("```typescript");
+    expect(text).toContain("const x: number = 42;");
+  });
+});
+
+// ============================================================
+// 6. DisplayAttachment textContent for user uploads
+// ============================================================
+
+describe("DisplayAttachment textContent for .md uploads", () => {
+  it("should read .md file content via File.text()", async () => {
+    const mdContent = "# Test\n\nHello world";
+    const file = new File([mdContent], "test.md", { type: "text/markdown" });
+
+    const text = await file.text();
+    expect(text).toBe(mdContent);
+    expect(text).toContain("# Test");
+  });
+
+  it("should handle empty .md file", async () => {
+    const file = new File([""], "empty.md", { type: "text/markdown" });
+    const text = await file.text();
+    expect(text).toBe("");
+  });
+
+  it("should handle large .md file (truncation scenario)", async () => {
+    const longContent = "# Long\n\n" + "Lorem ipsum dolor sit amet. ".repeat(1000);
+    const file = new File([longContent], "long.md", { type: "text/markdown" });
+    const text = await file.text();
+    expect(text.length).toBeGreaterThan(10000);
+  });
+});
+
+// ============================================================
+// 7. Multiple .md MEDIA: lines
+// ============================================================
+
+describe("multiple .md MEDIA: lines", () => {
+  const MEDIA_RE = /^MEDIA:(.+)$/gm;
+
+  it("extracts multiple .md files", () => {
+    const text = "MEDIA:/tmp/readme.md\nMEDIA:/tmp/changelog.md\nSome text.";
+    const matches: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = MEDIA_RE.exec(text)) !== null) {
+      matches.push(m[1].trim());
+    }
+    expect(matches).toEqual(["/tmp/readme.md", "/tmp/changelog.md"]);
+    expect(matches.every((p) => p.endsWith(".md"))).toBe(true);
+  });
+
+  it("mixes .md with other file types", () => {
+    const text = "MEDIA:/tmp/image.png\nMEDIA:/tmp/readme.md\nMEDIA:/tmp/video.mp4";
+    const matches: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = MEDIA_RE.exec(text)) !== null) {
+      matches.push(m[1].trim());
+    }
+    expect(matches).toHaveLength(3);
+    const mdFiles = matches.filter((p) => p.endsWith(".md"));
+    expect(mdFiles).toEqual(["/tmp/readme.md"]);
+  });
+});

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -325,11 +325,21 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
         await maybeAutoLabelSession(effectiveSessionKey, text);
         const payloads = await Promise.all(attachments.map(attachmentToPayload));
         const userMsg = text || "";
-        const displayAtts = attachments.map((att) => ({
-          fileName: att.file.name,
-          mimeType: att.file.type || "application/octet-stream",
-          dataUrl: att.preview || undefined,
-        }));
+        const displayAtts = await Promise.all(
+          attachments.map(async (att) => {
+            const ext = att.file.name.split(".").pop()?.toLowerCase();
+            let textContent: string | undefined;
+            if (ext === "md" || ext === "mdx") {
+              try { textContent = await att.file.text(); } catch {}
+            }
+            return {
+              fileName: att.file.name,
+              mimeType: att.file.type || "application/octet-stream",
+              dataUrl: att.preview || undefined,
+              textContent,
+            };
+          })
+        );
         addUserMessage(userMsg || "(첨부 파일)", displayAtts);
         if (client && isConnected) {
           // Send all attachments in a single request.

--- a/src/components/chat/file-attachments.tsx
+++ b/src/components/chat/file-attachments.tsx
@@ -79,6 +79,19 @@ function fileToAttachment(file: File): Promise<ChatAttachment> {
   });
 }
 
+/** Read text content from a file for inline preview (e.g. .md files) */
+export async function readTextContent(file: File): Promise<string | undefined> {
+  const ext = file.name.split(".").pop()?.toLowerCase();
+  if (ext === "md" || ext === "mdx") {
+    try {
+      return await file.text();
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
 // ---- Attachment preview bar ----
 
 export function AttachmentPreview({

--- a/src/components/chat/markdown-renderer.tsx
+++ b/src/components/chat/markdown-renderer.tsx
@@ -458,6 +458,66 @@ async function blobDownload(url: string, name: string) {
   }
 }
 
+/** Inline markdown file preview — fetches .md content and renders with MarkdownRenderer */
+export function MarkdownFilePreview({ src, fileName }: { src: string; fileName: string }) {
+  const [content, setContent] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch(src)
+      .then((r) => (r.ok ? r.text() : Promise.reject(new Error(`${r.status}`))))
+      .then(setContent)
+      .catch(() => setError(true));
+  }, [src]);
+
+  return (
+    <div className="my-2 w-full max-w-2xl overflow-hidden rounded-lg border border-zinc-700">
+      <div className="flex items-center justify-between bg-zinc-800 px-3 py-1.5 text-xs text-zinc-400">
+        <span className="flex items-center gap-1.5">
+          <FileText size={12} />
+          {fileName}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => {
+              const dlUrl = src.startsWith("/api/media") ? src + (src.includes("?") ? "&" : "?") + "dl=1" : src;
+              blobDownload(dlUrl, fileName);
+            }}
+            className="rounded px-1.5 py-0.5 hover:bg-zinc-700 hover:text-zinc-200 transition"
+            title="다운로드"
+          >
+            <Download size={12} />
+          </button>
+          <button
+            onClick={() => setExpanded((e) => !e)}
+            className="rounded px-1.5 py-0.5 hover:bg-zinc-700 hover:text-zinc-200 transition"
+          >
+            {expanded ? "접기" : "펼치기"}
+          </button>
+        </div>
+      </div>
+      {expanded && (
+        <div className="max-h-96 overflow-y-auto bg-zinc-900 px-4 py-3">
+          {error ? (
+            <div className="text-xs text-zinc-500">파일을 불러올 수 없습니다.</div>
+          ) : content === null ? (
+            <div className="text-xs text-zinc-500">불러오는 중...</div>
+          ) : content === "" ? (
+            <div className="text-xs text-zinc-500">(빈 파일)</div>
+          ) : (
+            <div className="prose prose-sm prose-invert max-w-none">
+              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={components}>
+                {content}
+              </ReactMarkdown>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function FileCard({ url, fileName, type }: { url: string; fileName: string; type: MediaType }) {
   const [fileInfo, setFileInfo] = useState<{ size: number } | null>(null);
   const accent = getMediaAccent(type);
@@ -507,6 +567,13 @@ function MediaRenderer({ entry }: { entry: MediaEntry }) {
       return <MediaAudio src={entry.url} fileName={entry.fileName} />;
     case "pdf":
       return <MediaPdf src={entry.url} fileName={entry.fileName} />;
+    case "text": {
+      const ext = getExtension(entry.fileName);
+      if (ext === "md" || ext === "mdx") {
+        return <MarkdownFilePreview src={entry.url} fileName={entry.fileName} />;
+      }
+      return <FileCard url={entry.url} fileName={entry.fileName} type={entry.type} />;
+    }
     default:
       return <FileCard url={entry.url} fileName={entry.fileName} type={entry.type} />;
   }

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -6,7 +6,7 @@ import {
   FileText, Music, Video, File, Image as ImageIcon,
   FileSpreadsheet, FileCode, FileArchive, FileAudio, FileVideo,
 } from "lucide-react";
-import { MarkdownRenderer } from "./markdown-renderer";
+import { MarkdownRenderer, MarkdownFilePreview } from "./markdown-renderer";
 import { ToolCallCard } from "./tool-call-card";
 import type { DisplayMessage, DisplayAttachment } from "@/lib/gateway/hooks";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
@@ -345,20 +345,35 @@ function MessageBubble({ message, showAvatar = true, onCancel, agentId }: { mess
             {/* Attachment images */}
             {message.attachments && message.attachments.length > 0 && (
               <div className="mb-2 flex flex-wrap gap-2">
-                {message.attachments.map((att, i) =>
-                  att.dataUrl && att.mimeType.startsWith("image/") ? (
-                    <img
-                      key={i}
-                      src={att.dataUrl}
-                      alt={att.fileName}
-                      className="max-h-48 w-full md:max-w-full md:w-auto rounded-lg object-contain"
-                    />
-                  ) : (
+                {message.attachments.map((att, i) => {
+                  if (att.dataUrl && att.mimeType.startsWith("image/")) {
+                    return (
+                      <img
+                        key={i}
+                        src={att.dataUrl}
+                        alt={att.fileName}
+                        className="max-h-48 w-full md:max-w-full md:w-auto rounded-lg object-contain"
+                      />
+                    );
+                  }
+                  if (att.textContent && (att.mimeType === "text/markdown" || att.fileName.endsWith(".md") || att.fileName.endsWith(".mdx"))) {
+                    return (
+                      <div key={i} className="w-full max-w-2xl overflow-hidden rounded-lg border border-zinc-600/50">
+                        <div className="flex items-center gap-1.5 bg-zinc-700/50 px-3 py-1.5 text-[11px] text-zinc-400">
+                          📎 {att.fileName}
+                        </div>
+                        <div className="max-h-60 overflow-y-auto bg-zinc-800/40 px-3 py-2 prose prose-sm prose-invert max-w-none">
+                          <MarkdownRenderer content={att.textContent} />
+                        </div>
+                      </div>
+                    );
+                  }
+                  return (
                     <div key={i} className="rounded-lg bg-white/10 px-3 py-1.5 text-xs">
                       📎 {att.fileName}
                     </div>
-                  )
-                )}
+                  );
+                })}
               </div>
             )}
             {message.content && message.content !== "(첨부 파일)" && (
@@ -428,6 +443,12 @@ function MessageBubble({ message, showAvatar = true, onCancel, agentId }: { mess
                         <div className="mt-1 text-[10px] text-zinc-500">{att.fileName}</div>
                       </div>
                     );
+                  }
+
+                  // Markdown file inline preview
+                  const ext = att.fileName.split(".").pop()?.toLowerCase();
+                  if (url && (ext === "md" || ext === "mdx")) {
+                    return <MarkdownFilePreview key={i} src={url} fileName={att.fileName} />;
                   }
 
                   // File card (vertical style)

--- a/src/lib/gateway/hooks.tsx
+++ b/src/lib/gateway/hooks.tsx
@@ -197,6 +197,8 @@ export interface DisplayAttachment {
   dataUrl?: string;
   /** URL for downloading the file (e.g. gateway-served MEDIA path) */
   downloadUrl?: string;
+  /** Raw text content for inline preview (e.g. .md files uploaded by user) */
+  textContent?: string;
 }
 
 /** Parse MEDIA:<path-or-url> lines from assistant content, returning attachments and cleaned text */

--- a/src/lib/mime-types.ts
+++ b/src/lib/mime-types.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared MIME type mapping — single source of truth for client + API.
+ * Key: extension WITHOUT dot (e.g. "png", "docx").
+ */
+export const MIME_MAP: Record<string, string> = {
+  // Images
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  ico: "image/x-icon",
+  bmp: "image/bmp",
+  tiff: "image/tiff",
+  tif: "image/tiff",
+  // Video
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  avi: "video/x-msvideo",
+  mkv: "video/x-matroska",
+  // Audio
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  flac: "audio/flac",
+  aac: "audio/aac",
+  m4a: "audio/mp4",
+  wma: "audio/x-ms-wma",
+  // Documents
+  pdf: "application/pdf",
+  doc: "application/msword",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  xls: "application/vnd.ms-excel",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ppt: "application/vnd.ms-powerpoint",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  // Text / Code
+  txt: "text/plain",
+  csv: "text/csv",
+  json: "application/json",
+  xml: "application/xml",
+  html: "text/html",
+  css: "text/css",
+  js: "text/javascript",
+  ts: "text/typescript",
+  md: "text/markdown",
+  yaml: "text/yaml",
+  yml: "text/yaml",
+  py: "text/x-python",
+  rs: "text/x-rust",
+  go: "text/x-go",
+  java: "text/x-java",
+  c: "text/x-c",
+  cpp: "text/x-c++",
+  h: "text/x-c",
+  sh: "text/x-shellscript",
+  sql: "text/x-sql",
+  log: "text/plain",
+  // Archives
+  zip: "application/zip",
+  tar: "application/x-tar",
+  gz: "application/gzip",
+  "7z": "application/x-7z-compressed",
+  rar: "application/vnd.rar",
+};
+
+/** Get MIME type by extension (without dot). Falls back to application/octet-stream. */
+export function getMimeType(ext: string): string {
+  return MIME_MAP[ext.toLowerCase()] || "application/octet-stream";
+}
+
+/** Get MIME type by extension WITH dot (e.g. ".png"). For API route compatibility. */
+export function getMimeTypeByDotExt(dotExt: string): string {
+  const ext = dotExt.startsWith(".") ? dotExt.slice(1) : dotExt;
+  return getMimeType(ext);
+}

--- a/src/lib/utils/download.ts
+++ b/src/lib/utils/download.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared blob-based download utility.
+ * Fetches a URL, validates the response, and triggers a browser download.
+ */
+export async function blobDownload(url: string, fileName: string): Promise<boolean> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.error(`[Download] Failed: ${res.status} ${res.statusText} — ${url}`);
+      return false;
+    }
+    const blob = await res.blob();
+    if (blob.size === 0) {
+      console.warn("[Download] Empty file:", url);
+      return false;
+    }
+    const blobUrl = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = blobUrl;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(blobUrl);
+    return true;
+  } catch (err) {
+    console.error("[Download] Error:", err, url);
+    return false;
+  }
+}
+
+/** Append dl=1 to /api/media URLs to force download */
+export function forceDownloadUrl(url: string): string {
+  if (url.startsWith("/api/media")) {
+    return url + (url.includes("?") ? "&" : "?") + "dl=1";
+  }
+  return url;
+}


### PR DESCRIPTION
## 요약
GitHub #9: .md 파일을 채팅 UI에서 렌더링된 미리보기로 표시

## 변경 사항

### A. Agent가 보낸 .md 파일 (MEDIA: 프로토콜)
- `MarkdownFilePreview` 컴포넌트 신규 추가 (`markdown-renderer.tsx`)
  - fetch → text → ReactMarkdown 렌더링
  - 접기/펼치기 토글
  - 다운로드 버튼
  - 최대 높이 384px + 스크롤
  - 에러/빈 파일 핸들링
- `MediaRenderer`에 `case "text"` 분기 추가 — .md/.mdx → MarkdownFilePreview

### B. 사용자가 업로드한 .md 파일
- `DisplayAttachment`에 `textContent` 필드 추가 (`hooks.tsx`)
- `chat-panel.tsx`에서 .md 업로드 시 `file.text()`로 내용 읽기
- `message-list.tsx`에서 user .md 첨부 인라인 렌더링

### C. Assistant .md 첨부 (hooks.tsx에서 추출된 attachment)
- `message-list.tsx` Assistant 첨부 영역에서 .md → MarkdownFilePreview 표시

## GFM 지원
기존 react-markdown + remark-gfm + rehype-highlight 스택 그대로 재사용:
- ✅ 테이블, 취소선, 체크리스트
- ✅ 코드 블록 구문 강조
- ✅ 링크, 이미지, 제목

## 테스트
- 23개 신규 테스트 (`markdown-preview.test.ts`)
- 전체 137 tests 통과, 빌드 성공

## 영향 파일
| 파일 | 수정 |
|---|---|
| `markdown-renderer.tsx` | MarkdownFilePreview 추가, MediaRenderer case 추가 |
| `message-list.tsx` | user/assistant .md 인라인 렌더링 |
| `hooks.tsx` | DisplayAttachment.textContent 필드 |
| `chat-panel.tsx` | .md 업로드 시 텍스트 읽기 |
| `file-attachments.tsx` | readTextContent 헬퍼 |

Closes #9