### PR TITLE
feat: #9 Markdown 파일 인라인 미리보기 지원

### DIFF
--- a/src/__tests__/markdown-preview.test.ts
+++ b/src/__tests__/markdown-preview.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getMimeType } from "@/lib/mime-types";
+
+// ============================================================
+// 1. MIME detection for .md files
+// ============================================================
+
+describe("markdown MIME detection", () => {
+  it("getMimeType returns text/markdown for md extension", () => {
+    expect(getMimeType("md")).toBe("text/markdown");
+  });
+
+  it("getMimeType returns text/plain for txt extension", () => {
+    expect(getMimeType("txt")).toBe("text/plain");
+  });
+});
+
+// ============================================================
+// 2. MEDIA: protocol with .md files — URL generation
+// ============================================================
+
+describe("MEDIA: protocol .md file handling", () => {
+  it("generates correct download URL for local .md path", () => {
+    const raw = "/tmp/readme.md";
+    const url = `/api/media?path=${encodeURIComponent(raw)}`;
+    expect(url).toBe("/api/media?path=%2Ftmp%2Freadme.md");
+  });
+
+  it("preserves http URL for remote .md file", () => {
+    const raw = "https://example.com/docs/readme.md";
+    const isHttp = raw.startsWith("http://") || raw.startsWith("https://");
+    expect(isHttp).toBe(true);
+  });
+
+  it("extracts .md extension correctly", () => {
+    const fileName = "PROJECT-README.md";
+    const ext = fileName.split(".").pop()?.toLowerCase() || "";
+    expect(ext).toBe("md");
+    expect(getMimeType(ext)).toBe("text/markdown");
+  });
+});
+
+// ============================================================
+// 3. detectMediaType — .md should be "text" type
+// ============================================================
+
+describe("detectMediaType for markdown files", () => {
+  // Mirror the logic from markdown-renderer.tsx
+  const TEXT_EXTS = ["txt", "md", "log", "json", "yaml", "yml"];
+
+  function detectMediaType(path: string): string {
+    const match = path.match(/\.(\w+)(?:\?|$)/);
+    const ext = match ? match[1].toLowerCase() : "";
+    if (TEXT_EXTS.includes(ext)) return "text";
+    return "other";
+  }
+
+  it("detects .md as text type", () => {
+    expect(detectMediaType("/tmp/readme.md")).toBe("text");
+  });
+
+  it("detects .txt as text type", () => {
+    expect(detectMediaType("/tmp/notes.txt")).toBe("text");
+  });
+
+  it("detects .log as text type", () => {
+    expect(detectMediaType("/var/log/app.log")).toBe("text");
+  });
+
+  it("detects unknown extension as other", () => {
+    expect(detectMediaType("/tmp/binary.dat")).toBe("other");
+  });
+});
+
+// ============================================================
+// 4. isMarkdownFile helper logic
+// ============================================================
+
+describe("isMarkdownFile detection", () => {
+  function isMarkdownFile(fileName: string, mimeType?: string): boolean {
+    if (mimeType === "text/markdown") return true;
+    const ext = fileName.split(".").pop()?.toLowerCase();
+    return ext === "md" || ext === "mdx";
+  }
+
+  it("detects .md by extension", () => {
+    expect(isMarkdownFile("readme.md")).toBe(true);
+  });
+
+  it("detects .mdx by extension", () => {
+    expect(isMarkdownFile("page.mdx")).toBe(true);
+  });
+
+  it("detects by MIME type", () => {
+    expect(isMarkdownFile("file", "text/markdown")).toBe(true);
+  });
+
+  it("rejects non-markdown files", () => {
+    expect(isMarkdownFile("image.png")).toBe(false);
+    expect(isMarkdownFile("doc.pdf")).toBe(false);
+    expect(isMarkdownFile("data.json")).toBe(false);
+  });
+
+  it("rejects text/plain (not markdown)", () => {
+    expect(isMarkdownFile("notes.txt", "text/plain")).toBe(false);
+  });
+});
+
+// ============================================================
+// 5. Markdown content fetch simulation
+// ============================================================
+
+describe("markdown content fetch", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  it("fetches and returns markdown content", async () => {
+    const mdContent = "# Hello\n\nThis is a **bold** paragraph.\n\n- Item 1\n- Item 2";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(mdContent),
+    });
+
+    const res = await fetch("/api/media?path=%2Ftmp%2Freadme.md");
+    expect(res.ok).toBe(true);
+    const text = await res.text();
+    expect(text).toContain("# Hello");
+    expect(text).toContain("**bold**");
+  });
+
+  it("handles fetch failure gracefully", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    });
+
+    const res = await fetch("/api/media?path=%2Ftmp%2Fmissing.md");
+    expect(res.ok).toBe(false);
+  });
+
+  it("handles GFM content (tables, strikethrough)", async () => {
+    const gfmContent = "| Col A | Col B |\n|-------|-------|\n| 1 | 2 |\n\n~~deleted~~\n\n- [x] Done\n- [ ] Todo";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(gfmContent),
+    });
+
+    const res = await fetch("/api/media?path=%2Ftmp%2Ftable.md");
+    const text = await res.text();
+    expect(text).toContain("| Col A |");
+    expect(text).toContain("~~deleted~~");
+    expect(text).toContain("[x] Done");
+  });
+
+  it("handles code blocks", async () => {
+    const codeContent = "```typescript\nconst x: number = 42;\n```";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(codeContent),
+    });
+
+    const text = await (await fetch("/api/media?path=%2Ftmp%2Fcode.md")).text();
+    expect(text).toContain("```typescript");
+    expect(text).toContain("const x: number = 42;");
+  });
+});
+
+// ============================================================
+// 6. DisplayAttachment textContent for user uploads
+// ============================================================
+
+describe("DisplayAttachment textContent for .md uploads", () => {
+  it("should read .md file content via File.text()", async () => {
+    const mdContent = "# Test\n\nHello world";
+    const file = new File([mdContent], "test.md", { type: "text/markdown" });
+
+    const text = await file.text();
+    expect(text).toBe(mdContent);
+    expect(text).toContain("# Test");
+  });
+
+  it("should handle empty .md file", async () => {
+    const file = new File([""], "empty.md", { type: "text/markdown" });
+    const text = await file.text();
+    expect(text).toBe("");
+  });
+
+  it("should handle large .md file (truncation scenario)", async () => {
+    const longContent = "# Long\n\n" + "Lorem ipsum dolor sit amet. ".repeat(1000);
+    const file = new File([longContent], "long.md", { type: "text/markdown" });
+    const text = await file.text();
+    expect(text.length).toBeGreaterThan(10000);
+  });
+});
+
+// ============================================================
+// 7. Multiple .md MEDIA: lines
+// ============================================================
+
+describe("multiple .md MEDIA: lines", () => {
+  const MEDIA_RE = /^MEDIA:(.+)$/gm;
+
+  it("extracts multiple .md files", () => {
+    const text = "MEDIA:/tmp/readme.md\nMEDIA:/tmp/changelog.md\nSome text.";
+    const matches: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = MEDIA_RE.exec(text)) !== null) {
+      matches.push(m[1].trim());
+    }
+    expect(matches).toEqual(["/tmp/readme.md", "/tmp/changelog.md"]);
+    expect(matches.every((p) => p.endsWith(".md"))).toBe(true);
+  });
+
+  it("mixes .md with other file types", () => {
+    const text = "MEDIA:/tmp/image.png\nMEDIA:/tmp/readme.md\nMEDIA:/tmp/video.mp4";
+    const matches: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = MEDIA_RE.exec(text)) !== null) {
+      matches.push(m[1].trim());
+    }
+    expect(matches).toHaveLength(3);
+    const mdFiles = matches.filter((p) => p.endsWith(".md"));
+    expect(mdFiles).toEqual(["/tmp/readme.md"]);
+  });
+});

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -331,11 +331,21 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
         await maybeAutoLabelSession(effectiveSessionKey, text);
         const payloads = await Promise.all(attachments.map(attachmentToPayload));
         const userMsg = text || "";
-        const displayAtts = attachments.map((att) => ({
-          fileName: att.file.name,
-          mimeType: att.file.type || "application/octet-stream",
-          dataUrl: att.preview || undefined,
-        }));
+        const displayAtts = await Promise.all(
+          attachments.map(async (att) => {
+            const ext = att.file.name.split(".").pop()?.toLowerCase();
+            let textContent: string | undefined;
+            if (ext === "md" || ext === "mdx") {
+              try { textContent = await att.file.text(); } catch {}
+            }
+            return {
+              fileName: att.file.name,
+              mimeType: att.file.type || "application/octet-stream",
+              dataUrl: att.preview || undefined,
+              textContent,
+            };
+          })
+        );
         addUserMessage(userMsg || "(첨부 파일)", displayAtts);
         if (client && isConnected) {
           // Send all attachments in a single request.

--- a/src/components/chat/file-attachments.tsx
+++ b/src/components/chat/file-attachments.tsx
@@ -79,6 +79,19 @@ function fileToAttachment(file: File): Promise<ChatAttachment> {
   });
 }
 
+/** Read text content from a file for inline preview (e.g. .md files) */
+export async function readTextContent(file: File): Promise<string | undefined> {
+  const ext = file.name.split(".").pop()?.toLowerCase();
+  if (ext === "md" || ext === "mdx") {
+    try {
+      return await file.text();
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
 // ---- Attachment preview bar ----
 
 export function AttachmentPreview({

--- a/src/components/chat/markdown-renderer.tsx
+++ b/src/components/chat/markdown-renderer.tsx
@@ -440,6 +440,63 @@ function getMediaAccent(type: MediaType): string {
   }
 }
 
+/** Inline markdown file preview — fetches .md content and renders with MarkdownRenderer */
+export function MarkdownFilePreview({ src, fileName }: { src: string; fileName: string }) {
+  const [content, setContent] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch(src)
+      .then((r) => (r.ok ? r.text() : Promise.reject(new Error(`${r.status}`))))
+      .then(setContent)
+      .catch(() => setError(true));
+  }, [src]);
+
+  return (
+    <div className="my-2 w-full max-w-2xl overflow-hidden rounded-lg border border-zinc-700">
+      <div className="flex items-center justify-between bg-zinc-800 px-3 py-1.5 text-xs text-zinc-400">
+        <span className="flex items-center gap-1.5">
+          <FileText size={12} />
+          {fileName}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => blobDownload(forceDownloadUrl(src), fileName)}
+            className="rounded px-1.5 py-0.5 hover:bg-zinc-700 hover:text-zinc-200 transition"
+            title="다운로드"
+          >
+            <Download size={12} />
+          </button>
+          <button
+            onClick={() => setExpanded((e) => !e)}
+            className="rounded px-1.5 py-0.5 hover:bg-zinc-700 hover:text-zinc-200 transition"
+          >
+            {expanded ? "접기" : "펼치기"}
+          </button>
+        </div>
+      </div>
+      {expanded && (
+        <div className="max-h-96 overflow-y-auto bg-zinc-900 px-4 py-3">
+          {error ? (
+            <div className="text-xs text-zinc-500">파일을 불러올 수 없습니다.</div>
+          ) : content === null ? (
+            <div className="text-xs text-zinc-500">불러오는 중...</div>
+          ) : content === "" ? (
+            <div className="text-xs text-zinc-500">(빈 파일)</div>
+          ) : (
+            <div className="prose prose-sm prose-invert max-w-none">
+              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={components}>
+                {content}
+              </ReactMarkdown>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function FileCard({ url, fileName, type }: { url: string; fileName: string; type: MediaType }) {
   const [fileInfo, setFileInfo] = useState<{ size: number } | null>(null);
   const accent = getMediaAccent(type);
@@ -489,6 +546,13 @@ function MediaRenderer({ entry }: { entry: MediaEntry }) {
       return <MediaAudio src={entry.url} fileName={entry.fileName} />;
     case "pdf":
       return <MediaPdf src={entry.url} fileName={entry.fileName} />;
+    case "text": {
+      const ext = getExtension(entry.fileName);
+      if (ext === "md" || ext === "mdx") {
+        return <MarkdownFilePreview src={entry.url} fileName={entry.fileName} />;
+      }
+      return <FileCard url={entry.url} fileName={entry.fileName} type={entry.type} />;
+    }
     default:
       return <FileCard url={entry.url} fileName={entry.fileName} type={entry.type} />;
   }

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -6,7 +6,7 @@ import {
   FileText, Music, Video, File, Image as ImageIcon,
   FileSpreadsheet, FileCode, FileArchive, FileAudio, FileVideo,
 } from "lucide-react";
-import { MarkdownRenderer } from "./markdown-renderer";
+import { MarkdownRenderer, MarkdownFilePreview } from "./markdown-renderer";
 import { ToolCallCard } from "./tool-call-card";
 import type { DisplayMessage, DisplayAttachment } from "@/lib/gateway/hooks";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
@@ -333,20 +333,35 @@ function MessageBubble({ message, showAvatar = true, onCancel, agentId }: { mess
             {/* Attachment images */}
             {message.attachments && message.attachments.length > 0 && (
               <div className="mb-2 flex flex-wrap gap-2">
-                {message.attachments.map((att, i) =>
-                  att.dataUrl && att.mimeType.startsWith("image/") ? (
-                    <img
-                      key={i}
-                      src={att.dataUrl}
-                      alt={att.fileName}
-                      className="max-h-48 w-full md:max-w-full md:w-auto rounded-lg object-contain"
-                    />
-                  ) : (
+                {message.attachments.map((att, i) => {
+                  if (att.dataUrl && att.mimeType.startsWith("image/")) {
+                    return (
+                      <img
+                        key={i}
+                        src={att.dataUrl}
+                        alt={att.fileName}
+                        className="max-h-48 w-full md:max-w-full md:w-auto rounded-lg object-contain"
+                      />
+                    );
+                  }
+                  if (att.textContent && (att.mimeType === "text/markdown" || att.fileName.endsWith(".md") || att.fileName.endsWith(".mdx"))) {
+                    return (
+                      <div key={i} className="w-full max-w-2xl overflow-hidden rounded-lg border border-zinc-600/50">
+                        <div className="flex items-center gap-1.5 bg-zinc-700/50 px-3 py-1.5 text-[11px] text-zinc-400">
+                          📎 {att.fileName}
+                        </div>
+                        <div className="max-h-60 overflow-y-auto bg-zinc-800/40 px-3 py-2 prose prose-sm prose-invert max-w-none">
+                          <MarkdownRenderer content={att.textContent} />
+                        </div>
+                      </div>
+                    );
+                  }
+                  return (
                     <div key={i} className="rounded-lg bg-white/10 px-3 py-1.5 text-xs">
                       📎 {att.fileName}
                     </div>
-                  )
-                )}
+                  );
+                })}
               </div>
             )}
             {message.content && message.content !== "(첨부 파일)" && (
@@ -416,6 +431,12 @@ function MessageBubble({ message, showAvatar = true, onCancel, agentId }: { mess
                         <div className="mt-1 text-[10px] text-zinc-500">{att.fileName}</div>
                       </div>
                     );
+                  }
+
+                  // Markdown file inline preview
+                  const ext = att.fileName.split(".").pop()?.toLowerCase();
+                  if (url && (ext === "md" || ext === "mdx")) {
+                    return <MarkdownFilePreview key={i} src={url} fileName={att.fileName} />;
                   }
 
                   // File card (vertical style)

--- a/src/lib/gateway/hooks.tsx
+++ b/src/lib/gateway/hooks.tsx
@@ -198,6 +198,8 @@ export interface DisplayAttachment {
   dataUrl?: string;
   /** URL for downloading the file (e.g. gateway-served MEDIA path) */
   downloadUrl?: string;
+  /** Raw text content for inline preview (e.g. .md files uploaded by user) */
+  textContent?: string;
 }
 
 /** Parse MEDIA:<path-or-url> lines from assistant content, returning attachments and cleaned text */


### PR DESCRIPTION
## Summary
- .md 파일을 채팅 UI에서 렌더링된 미리보기로 표시
- 기존 PR #35를 #34 merge 이후 충돌 해결하여 재생성

## 변경 사항

### A. Agent가 보낸 .md 파일 (MEDIA: 프로토콜)
- `MarkdownFilePreview` 컴포넌트 신규 추가
- fetch → text → ReactMarkdown 렌더링
- 접기/펼치기, 다운로드 (공통 `blobDownload`/`forceDownloadUrl` 사용)
- `MediaRenderer`에 `case "text"` → .md/.mdx 분기 추가

### B. 사용자가 업로드한 .md 파일
- `DisplayAttachment`에 `textContent` 필드 추가
- `chat-panel.tsx`에서 .md 업로드 시 `file.text()`로 내용 읽기
- `message-list.tsx`에서 user .md 인라인 렌더링

### C. Assistant .md 첨부
- `message-list.tsx` Assistant 영역에서 .md → `MarkdownFilePreview` 표시

## 테스트
- 23개 신규 테스트 (`markdown-preview.test.ts`)
- 전체 247개 테스트 통과

## Test plan
- [ ] MEDIA:/tmp/readme.md → 인라인 렌더링 미리보기 표시
- [ ] 접기/펼치기 토글 동작
- [ ] 다운로드 버튼 동작
- [ ] 사용자 .md 파일 업로드 → 인라인 미리보기
- [ ] GFM (테이블, 코드 블록, 체크리스트) 정상 렌더링

Supersedes #35
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)