### PR TITLE
feat: 채팅 타임스탬프 MM-DD-YYYY HH:MM:SS 포맷 적용

### DIFF
--- a/src/__tests__/timestamp-format.test.ts
+++ b/src/__tests__/timestamp-format.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { formatTime } from "../lib/utils/format-time";
+
+describe("formatTime", () => {
+  it("returns null for undefined input", () => {
+    expect(formatTime(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(formatTime("")).toBeNull();
+  });
+
+  it("returns null for invalid date string", () => {
+    expect(formatTime("not-a-date")).toBeNull();
+  });
+
+  it("formats ISO timestamp as MM-DD-YYYY HH:MM:SS in KST", () => {
+    // 2026-02-25T02:30:45Z = 2026-02-25 11:30:45 KST
+    const result = formatTime("2026-02-25T02:30:45Z");
+    expect(result).toBe("02-25-2026 11:30:45");
+  });
+
+  it("handles midnight KST correctly", () => {
+    // 2026-01-01T15:00:00Z = 2026-01-02 00:00:00 KST
+    const result = formatTime("2026-01-01T15:00:00Z");
+    expect(result).toBe("01-02-2026 00:00:00");
+  });
+
+  it("handles single-digit seconds with zero padding", () => {
+    // 2026-07-15T10:05:03Z = 2026-07-15 19:05:03 KST
+    const result = formatTime("2026-07-15T10:05:03Z");
+    expect(result).toBe("07-15-2026 19:05:03");
+  });
+
+  it("handles date near year boundary", () => {
+    // 2025-12-31T15:30:00Z = 2026-01-01 00:30:00 KST
+    const result = formatTime("2025-12-31T15:30:00Z");
+    expect(result).toBe("01-01-2026 00:30:00");
+  });
+});

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -12,6 +12,7 @@ import type { DisplayMessage, DisplayAttachment } from "@/lib/gateway/hooks";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
 
 import { blobDownload, forceDownloadUrl } from "@/lib/utils/download";
+import { formatTime } from "@/lib/utils/format-time";
 
 /** Get file extension from filename */
 function getExt(name: string): string {
@@ -270,22 +271,6 @@ function CopyButton({ text }: { text: string }) {
       {copied ? <Check size={12} className="text-emerald-400" /> : <Copy size={12} />}
     </button>
   );
-}
-
-/** Format timestamp to HH:MM (today) or MM/DD HH:MM (other days), KST */
-function formatTime(ts?: string): string | null {
-  if (!ts) return null;
-  try {
-    const d = new Date(ts);
-    if (isNaN(d.getTime())) return null;
-    const tz = { timeZone: "Asia/Seoul" as const };
-    const time = d.toLocaleTimeString("ko-KR", { ...tz, hour: "2-digit", minute: "2-digit", hour12: false });
-    const kstDate = d.toLocaleDateString("fr-CA", { ...tz, year: "numeric", month: "2-digit", day: "2-digit" }); // YYYY-MM-DD
-    const kstToday = new Date().toLocaleDateString("fr-CA", { ...tz, year: "numeric", month: "2-digit", day: "2-digit" });
-    if (kstDate === kstToday) return time;
-    const short = d.toLocaleDateString("ko-KR", { ...tz, month: "2-digit", day: "2-digit" });
-    return `${short} ${time}`;
-  } catch { return null; }
 }
 
 function MessageBubble({ message, showAvatar = true, onCancel, agentId }: { message: DisplayMessage; showAvatar?: boolean; onCancel?: (id: string) => void; agentId?: string }) {

--- a/src/lib/utils/format-time.ts
+++ b/src/lib/utils/format-time.ts
@@ -1,0 +1,32 @@
+/** Format timestamp to MM-DD-YYYY HH:MM:SS (KST) */
+export function formatTime(ts?: string): string | null {
+  if (!ts) return null;
+  try {
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return null;
+    const tz = { timeZone: "Asia/Seoul" as const };
+
+    const parts = new Intl.DateTimeFormat("en-US", {
+      ...tz,
+      month: "2-digit",
+      day: "2-digit",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    }).formatToParts(d);
+
+    const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "00";
+    const month = get("month");
+    const day = get("day");
+    const year = get("year");
+    const hour = get("hour");
+    const minute = get("minute");
+    const second = get("second");
+
+    return `${month}-${day}-${year} ${hour}:${minute}:${second}`;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 변경사항
- 채팅 메시지 타임스탬프를 **MM-DD-YYYY HH:MM:SS** (KST) 형식으로 변경
- `formatTime` 함수를 `src/lib/utils/format-time.ts`로 분리
- 7건의 단위 테스트 추가 (전체 통과)

## 기존 → 변경
- `11:30` → `02-25-2026 11:30:45`
- `02. 25. 11:30` → `02-25-2026 11:30:45`

Closes #38