### PR TITLE
feat: 폰트 가독성 개선 — Geist Sans + Pretendard

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^11.18.2",
+    "geist": "^1.7.0",
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.574.0",
     "next": "^15.5.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       framer-motion:
         specifier: ^11.18.2
         version: 11.18.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      geist:
+        specifier: ^1.7.0
+        version: 1.7.0(next@15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -2968,6 +2971,11 @@ packages:
 
   fzf@0.5.2:
     resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
+
+  geist@1.7.0:
+    resolution: {integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==}
+    peerDependencies:
+      next: '>=13.2.0'
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -7807,6 +7815,10 @@ snapshots:
   fuzzysort@3.1.0: {}
 
   fzf@0.5.2: {}
+
+  geist@1.7.0(next@15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+    dependencies:
+      next: 15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   generator-function@2.0.1: {}
 

--- a/src/__tests__/font-setup.test.ts
+++ b/src/__tests__/font-setup.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const layoutPath = resolve(__dirname, "../app/layout.tsx");
+const cssPath = resolve(__dirname, "../styles/globals.css");
+
+function readSrc(path: string) {
+  return readFileSync(path, "utf-8");
+}
+
+describe("Font setup", () => {
+  describe("layout.tsx", () => {
+    it("imports geist font package", () => {
+      const src = readSrc(layoutPath);
+      expect(src).toMatch(/from\s+["']geist\/font\/sans["']/);
+    });
+
+    it("applies geist font variable class to html element", () => {
+      const src = readSrc(layoutPath);
+      expect(src).toMatch(/GeistSans\.variable/);
+    });
+  });
+
+  describe("globals.css", () => {
+    it("includes Pretendard CDN import", () => {
+      const src = readSrc(cssPath);
+      expect(src).toMatch(/pretendard/i);
+    });
+
+    it("sets --font-sans with Geist Sans and Pretendard in stack", () => {
+      const src = readSrc(cssPath);
+      // Should contain both fonts in the sans variable
+      expect(src).toMatch(/--font-sans.*Geist\s*Sans/i);
+      expect(src).toMatch(/--font-sans.*Pretendard/i);
+    });
+
+    it("does not reference Inter as primary font", () => {
+      const src = readSrc(cssPath);
+      // --font-sans should no longer start with Inter
+      const fontSansLine = src.match(/--font-sans:\s*([^;]+);/)?.[1] ?? "";
+      expect(fontSansLine).not.toMatch(/^["']?Inter["']?/);
+    });
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { GeistSans } from "geist/font/sans";
 import { GatewayProvider } from "@/lib/gateway/hooks";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import "@/styles/globals.css";
@@ -29,7 +30,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ko" className="dark">
+    <html lang="ko" className={`dark ${GeistSans.variable}`}>
       <head>
         <link rel="apple-touch-icon" href="/icon-192.png" />
       </head>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,7 @@
 @import "highlight.js/styles/github-dark.min.css";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css");
 
 @custom-variant dark (&:is(.dark *));
 
@@ -27,7 +28,7 @@
   --color-input: #222222;
   --color-ring: #FF6B35;
   --radius: 0.625rem;
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: var(--font-geist-sans, "Geist Sans"), "Pretendard Variable", "Pretendard", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   --font-mono: "SF Mono", "Fira Code", "JetBrains Mono", ui-monospace, monospace;
 }
 
@@ -44,6 +45,10 @@ body {
   background-color: var(--color-background);
   color: var(--color-foreground);
   font-family: var(--font-sans);
+  letter-spacing: -0.01em;
+  font-feature-settings: "ss01", "ss02", "cv01";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
## 변경사항
- **라틴:** Geist Sans (next/font, variable font)
- **한글:** Pretendard Variable (CDN, dynamic subset)
- font-smoothing, letter-spacing(-0.01em), OpenType feature 적용

## 기존 → 변경
- `Inter → ui-sans-serif → system-ui` (Inter 미로딩 상태)
- `Geist Sans → Pretendard → -apple-system → system-ui`

## 테스트
- 5건 통과 (폰트 import, variable class, CDN, font stack, Inter 제거 확인)

## 스크린샷
머지 전 로컬에서 확인 부탁드립니다 (`pnpm dev`)

Closes #40