### PR TITLE
fix: 스트리밍 중 자동 스크롤이 실시간으로 따라가도록 수정

### DIFF
--- a/apps/web/src/components/chat/message-list.tsx
+++ b/apps/web/src/components/chat/message-list.tsx
@@ -153,15 +153,20 @@ export function MessageList({
   }, []);
 
   // Auto-scroll only when user is at the bottom
-  // Use message count + streaming state as trigger (not full messages array) to reduce jitter
+  // Track message count, streaming state, AND content length so scroll follows during streaming
   const msgCount = messages.length;
-  const lastStreaming = messages[messages.length - 1]?.streaming;
+  const lastMsg = messages[messages.length - 1];
+  const lastStreaming = lastMsg?.streaming;
+  const lastContentLen = lastMsg?.content?.length ?? 0;
   useEffect(() => {
     if (!userScrolledUp) {
-      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+      const el = containerRef.current;
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+      }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [msgCount, lastStreaming, userScrolledUp]);
+  }, [msgCount, lastStreaming, lastContentLen, userScrolledUp]);
 
   const scrollToBottom = useCallback(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });


### PR DESCRIPTION
## 문제
스트리밍 중 메시지가 길어져도 스크롤이 자동으로 따라가지 않고, 메시지 완료 후에만 한 번에 내려감

## 수정 내용
- `lastContentLen` 트래킹 추가: 콘텐츠 길이 변화 시마다 스크롤 트리거
- `scrollIntoView('smooth')` → `scrollTop = scrollHeight`: 연속 호출 시 smooth 애니메이션이 뭉치는 문제 방지

## 변경 파일
- `apps/web/src/components/chat/message-list.tsx`