### PR TITLE
fix: stop dropping streaming events when sessionKey is absent

### DIFF
--- a/apps/web/src/lib/gateway/hooks.tsx
+++ b/apps/web/src/lib/gateway/hooks.tsx
@@ -706,10 +706,10 @@ export function useChat(sessionKey?: string) {
       // nest the key inside data depending on event type (#48)
       const evSessionKey = (raw.sessionKey ?? data?.sessionKey) as string | undefined;
       if (evSessionKey && evSessionKey !== sessionKeyRef.current) return;
-      // If the event has no sessionKey, allow it through when we have an
-      // active runId (the event likely belongs to the current run) or when
-      // it's a lifecycle event that will set the runId. (#72)
-      if (!evSessionKey && sessionKeyRef.current && stream !== "lifecycle" && !runIdRef.current) return;
+      // When evSessionKey is absent, assume the event belongs to the current
+      // session — the gateway may omit sessionKey from streamed agent events.
+      // Previously we dropped these unless runIdRef was set, which caused
+      // assistant messages to silently disappear when runId was missing. (#72)
 
 
       // Ignore events after abort until next lifecycle start


### PR DESCRIPTION
## 문제
에이전트 응답 생성 중 메시지가 UI에 표시되지 않고 끝나는 경우가 있음. 새로고침하면 히스토리 API를 통해 정상적으로 보임.

## 원인
Gateway의 agent 이벤트 중 일부가 payload에 `sessionKey`를 포함하지 않음. 기존 필터 로직이 `sessionKey` 없고 `runIdRef`도 없는 이벤트를 전부 drop하여, 스트리밍 청크가 UI에 반영되지 않았음.

## 수정
`sessionKey`가 없는 이벤트는 현재 세션의 것으로 간주. `sessionKey`가 있고 현재 세션과 다른 경우만 필터링.

Relates to #72