### PR TITLE
fix: Cmd+W가 창 닫기 대신 토픽 탭 가리기로 동작하는 버그 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ pnpm start --port 4100
 | `Cmd+K` | Open session switcher |
 | `Cmd+N` | New session |
 | `Cmd+\` | Split panel |
-| `Cmd+W` | Close panel |
 | `Cmd+1-9` | Switch to panel N |
 | `Enter` | Send message |
 | `Shift+Enter` | New line |

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -160,21 +160,6 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
         createSessionForAgent(agentId);
         return;
       }
-      // Cmd+W: close current tab (except main session)
-      // If it's the main session (not closable), let the event propagate
-      // so Electron's native menu can handle window close
-      if (matchesShortcutId(e, "close-tab")) {
-        if (effectiveSessionKey) {
-          const p = parseSessionKey(effectiveSessionKey);
-          if (p.type !== "main") {
-            e.preventDefault();
-            handleDelete(effectiveSessionKey);
-            return;
-          }
-        }
-        // Don't preventDefault — let Electron close the window
-        return;
-      }
       // Cmd+1~9: switch to specific tab (9 = last tab)
       if (e.key >= "1" && e.key <= "9" && matchesShortcutId(e, `switch-tab-${e.key}`)) {
         e.preventDefault();

--- a/apps/web/src/lib/shortcuts.ts
+++ b/apps/web/src/lib/shortcuts.ts
@@ -30,7 +30,6 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
   { id: "session-switcher", keys: isMac ? "Cmd+K" : "Ctrl+K", description: "세션 스위처 열기", scope: "panel" },
   { id: "agent-browser", keys: isMac ? "Cmd+O" : "Ctrl+O", description: "에이전트별 세션 브라우저", scope: "panel" },
   { id: "new-tab", keys: isMac ? "Cmd+T" : "Ctrl+T", description: "새 탭 열기 (세션 생성)", scope: "panel" },
-  { id: "close-tab", keys: isMac ? "Cmd+W" : "Ctrl+W", description: "현재 탭 닫기", scope: "panel" },
   { id: "switch-tab-1", keys: isMac ? "Cmd+1" : "Alt+1", description: "탭 1로 이동", scope: "panel" },
   { id: "switch-tab-2", keys: isMac ? "Cmd+2" : "Alt+2", description: "탭 2로 이동", scope: "panel" },
   { id: "switch-tab-3", keys: isMac ? "Cmd+3" : "Alt+3", description: "탭 3로 이동", scope: "panel" },


### PR DESCRIPTION
Closes #81

## 변경 사항
- Cmd+W 키 바인딩 오버라이드를 제거하여 OS 기본 창 닫기 동작 복원

## 테스트
- Cmd+W 입력 시 창이 정상적으로 닫히는지 확인