### PR TITLE
fix: InputBox 포커스 이동 시 bubble focus 사라지도록

### DIFF
--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -281,6 +281,7 @@ export function ChatInput({
     <div
       className="relative px-[3%] py-1.5 sm:py-2 md:px-[5%] lg:px-[7%] safe-bottom electron-bottom-pad"
       style={isMobile && keyboardHeight > 0 ? { paddingBottom: `max(4px, env(safe-area-inset-bottom, 0px))` } : undefined}
+      onMouseDown={() => document.dispatchEvent(new CustomEvent("focus-chat-input"))}
     >
       {/* Skill picker */}
       <SkillPicker
@@ -398,6 +399,7 @@ export function ChatInput({
               value={text}
               onChange={(e) => setText(e.target.value)}
               onKeyDown={handleKeyDown}
+              onFocus={() => document.dispatchEvent(new CustomEvent("focus-chat-input"))}
               onPaste={handlePaste}
               onCompositionStart={() => {
                 composingRef.current = true;


### PR DESCRIPTION
Closes #83

## 변경 사항
- ChatInput 컨테이너에 onMouseDown 핸들러 추가하여 입력 영역 클릭 시 bubble focus 해제
- 기존 onFocus 이벤트와 함께 이중 보호

## 테스트
- Normal 모드에서 j/k로 버블 이동 후 입력창 클릭 → 버블 하이라이트 즉시 해제 확인