### PR TITLE
feat: 채팅창 비우기 기능 추가

### DIFF
--- a/apps/web/src/components/chat/chat-header.tsx
+++ b/apps/web/src/components/chat/chat-header.tsx
@@ -2,7 +2,7 @@
 import { useMemo, useRef, useEffect, useState, useCallback } from "react";
 import {
   MessageSquare, Plus, X, Pin, Zap,
-  MessageCircle, Bot, Settings, History,
+  MessageCircle, Bot, Settings, History, Trash2,
 } from "lucide-react";
 import { parseSessionKey } from "@/lib/gateway/session-utils";
 import { isSessionHidden, hideSession } from "@/lib/gateway/hidden-sessions";
@@ -31,6 +31,7 @@ interface ChatHeaderProps {
   onRenameSession?: (key: string, label: string) => void;
   onOpenSessionManager?: () => void;
   onOpenTopicHistory?: () => void;
+  onClearMessages?: () => void;
 }
 
 // --- Constants ---
@@ -160,6 +161,7 @@ export function ChatHeader({
   onRenameSession,
   onOpenSessionManager,
   onOpenTopicHistory,
+  onClearMessages,
 }: ChatHeaderProps) {
   const [confirmDeleteKey, setConfirmDeleteKey] = useState<string | null>(null);
   const [editingKey, setEditingKey] = useState<string | null>(null);
@@ -371,6 +373,15 @@ export function ChatHeader({
           >
             <History size={10} />
             <span>세션 {topicCount}</span>
+          </button>
+        )}
+        {onClearMessages && (
+          <button
+            onClick={onClearMessages}
+            className="flex items-center gap-1 rounded-md bg-zinc-800/50 border border-zinc-700/30 px-1.5 py-0.5 text-[10px] font-medium text-zinc-400 hover:bg-red-900/30 hover:border-red-500/30 hover:text-red-400 transition"
+            title="채팅 비우기"
+          >
+            <Trash2 size={10} />
           </button>
         )}
         {(() => {

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -72,7 +72,7 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
   const effectiveSessionKey =
     sessionKey || (agentId ? `agent:${agentId}:main` : mainSessionKey) || undefined;
 
-  const { messages, streaming, loading, agentStatus, sendMessage, sendCommand, addUserMessage, addLocalMessage, cancelQueued, abort, sendContextBridge } = useChat(effectiveSessionKey);
+  const { messages, streaming, loading, agentStatus, sendMessage, sendCommand, addUserMessage, addLocalMessage, clearMessages, cancelQueued, abort, sendContextBridge } = useChat(effectiveSessionKey);
   const { agents } = useAgents();
   const { sessions, loading: sessionsLoading, refresh: refreshSessions, patchSession } = useSessions();
 
@@ -338,6 +338,12 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
         return;
       }
 
+      // /clear — clear chat display (keep server history)
+      if (trimmed === "/clear") {
+        clearMessages();
+        return;
+      }
+
       // /help — show help table locally
       if (trimmed === "/help") {
         addLocalMessage(text, "user");
@@ -349,6 +355,7 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
           "| `/status` | 현재 세션 상태 표시 |",
           "| `/model` | 현재 모델 표시 |",
           "| `/model <name>` | 모델 변경 |",
+          "| `/clear` | 채팅 표시 비우기 |",
           "| `/new` | 새 스레드 생성 |",
           "| `/reset` | 세션 초기화 |",
           "| `/reasoning <level>` | 추론 레벨 변경 |",
@@ -480,7 +487,7 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
         sendMessage(text);
       }
     },
-    [attachments, client, isConnected, effectiveSessionKey, sessionKey, clearAttachments, sendMessage, sendCommand, addUserMessage, addLocalMessage, handleStatusCommand, patchSession, abort, refreshSessions, sessions, summarizeLabelFromText]
+    [attachments, client, isConnected, effectiveSessionKey, sessionKey, clearAttachments, sendMessage, sendCommand, addUserMessage, addLocalMessage, clearMessages, handleStatusCommand, patchSession, abort, refreshSessions, sessions, summarizeLabelFromText]
   );
 
   const handleAgentChange = (id: string | undefined) => {
@@ -605,6 +612,11 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
           onRenameSession={(key, label) => handleRename(key, label)}
           onOpenSessionManager={() => setSessionManagerOpen(true)}
           onOpenTopicHistory={() => setTopicHistoryOpen(true)}
+          onClearMessages={() => {
+            if (window.confirm("채팅 내용을 모두 비우시겠습니까?")) {
+              clearMessages();
+            }
+          }}
         />
       )}
 
@@ -624,6 +636,11 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
           agentStatus={agentStatus}
           onLoadPreviousContext={sendContextBridge}
           onOpenTopicHistory={() => setTopicHistoryOpen(true)}
+          onClearMessages={() => {
+            if (window.confirm("채팅 내용을 모두 비우시겠습니까?")) {
+              clearMessages();
+            }
+          }}
         />
       </DropZone>
 

--- a/apps/web/src/components/chat/skill-picker.tsx
+++ b/apps/web/src/components/chat/skill-picker.tsx
@@ -19,6 +19,7 @@ export const BUILTIN_COMMANDS: BuiltinCommand[] = [
   { name: "status", description: "세션 상태 확인 (토큰, 모델 등)", emoji: "📊", immediate: true },
   { name: "reasoning", description: "추론 모드 토글", emoji: "🧠", immediate: true },
   { name: "model", description: "모델 변경 (예: /model opus)", emoji: "🤖" },
+  { name: "clear", description: "채팅 표시 비우기", emoji: "🧹", immediate: true },
   { name: "help", description: "사용 가능한 커맨드 목록", emoji: "❓", immediate: true },
 ];
 

--- a/apps/web/src/lib/gateway/hooks.tsx
+++ b/apps/web/src/lib/gateway/hooks.tsx
@@ -1034,6 +1034,10 @@ export function useChat(sessionKey?: string) {
     setMessages((prev) => [...prev, { id: msgId, role, content, timestamp: new Date().toISOString(), toolCalls: [] }]);
   }, []);
 
+  const clearMessages = useCallback(() => {
+    setMessages([]);
+  }, []);
+
   const sendCommand = useCallback(
     async (text: string) => {
       if (!client || state !== "connected") return;
@@ -1131,7 +1135,7 @@ export function useChat(sessionKey?: string) {
 
   return {
     messages, streaming, loading, agentStatus,
-    sendMessage, sendCommand, addUserMessage, addLocalMessage,
+    sendMessage, sendCommand, addUserMessage, addLocalMessage, clearMessages,
     cancelQueued, abort, reload: loadHistory, sendContextBridge,
   };
 }


### PR DESCRIPTION
Closes #86

## 변경 사항
- ChatHeader에 🗑️ 아이콘 버튼 추가 (채팅 비우기)
- 클릭 시 확인 다이얼로그 표시 후 채팅 내용 초기화
- 기존 /clear 커맨드도 그대로 동작

## 테스트
- 헤더 휴지통 아이콘 클릭 → 확인 → 채팅 비워지는지 확인
- 확인 취소 시 채팅 유지