### PR TITLE
fix: 서브에이전트 완료 알림 추가

### DIFF
--- a/apps/web/src/components/chat/subagent-stream.tsx
+++ b/apps/web/src/components/chat/subagent-stream.tsx
@@ -63,6 +63,21 @@ export function SubagentStream({ currentSessionKey }: { currentSessionKey?: stri
           existing.toolName = undefined;
         } else if (stream === "lifecycle" && data?.phase === "end") {
           existing.status = "done";
+          // Send completion notification
+          try {
+            const label = existing.label || evSessionKey;
+            if (document.hidden) {
+              // App not focused: use browser Notification API
+              if (Notification.permission === "granted") {
+                new Notification("작업 완료", {
+                  body: `${label} 작업이 완료되었습니다.`,
+                  icon: "/logo.svg",
+                });
+              } else if (Notification.permission === "default") {
+                Notification.requestPermission();
+              }
+            }
+          } catch { /* ignore notification errors */ }
         }
 
         existing.updatedAt = Date.now();


### PR DESCRIPTION
Closes #91

## 변경 사항
- 서브에이전트 태스크 완료 시 브라우저 Notification API로 알림
- 앱이 백그라운드(document.hidden)일 때만 브라우저 알림 표시
- 알림 권한 미설정 시 자동 요청

## 테스트
- 서브에이전트 실행 후 다른 탭으로 전환 → 완료 시 알림 확인