### PR TITLE
feat: Normal 모드에서 v키로 셀렉트 모드 진입

### DIFF
--- a/apps/web/src/components/chat/message-list.tsx
+++ b/apps/web/src/components/chat/message-list.tsx
@@ -338,6 +338,17 @@ export function MessageList({
         return;
       }
 
+      // v → enter visual select mode (toggle select on focused message)
+      if (e.key === "v" && !e.shiftKey && focusedIdx !== null) {
+        e.preventDefault();
+        setSelectedIndices((s) => {
+          const n = new Set(s);
+          if (n.has(focusedIdx)) n.delete(focusedIdx); else n.add(focusedIdx);
+          return n;
+        });
+        return;
+      }
+
       // j → next message
       if (e.key === "j" && !e.shiftKey) {
         e.preventDefault();


### PR DESCRIPTION
Closes #82

## 변경 사항
- Normal 모드에서 v키 입력 시 현재 포커스된 메시지 선택 토글
- 기존 Space 키와 동일한 동작, vim visual mode 패턴 준수
- 선택된 메시지는 amber outline으로 표시 (기존 스타일링 활용)

## 테스트
- Normal 모드에서 j/k로 이동 후 v키 입력 → 선택 토글 확인