### PR TITLE
feat: clarify session/topic UI, add session close/reopen (#84, #85, #89, #90)

### DIFF
--- a/apps/web/src/components/chat/chat-header.tsx
+++ b/apps/web/src/components/chat/chat-header.tsx
@@ -369,10 +369,10 @@ export function ChatHeader({
           <button
             onClick={onOpenTopicHistory}
             className="flex items-center gap-1 rounded-md bg-amber-900/20 border border-amber-600/20 px-2 py-0.5 text-[10px] font-medium text-amber-500 hover:bg-amber-900/40 hover:border-amber-500/40 transition"
-            title="세션 이력 보기"
+            title="대화 이력 보기 (리셋 기록)"
           >
             <History size={10} />
-            <span>세션 {topicCount}</span>
+            <span>대화 {topicCount}</span>
           </button>
         )}
         {onClearMessages && (

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -9,7 +9,7 @@ import { SessionSwitcher } from "./session-switcher";
 import { AgentBrowser } from "./agent-browser";
 import { DropZone, useFileAttachments, attachmentToPayload } from "./file-attachments";
 import { parseSessionKey, sessionDisplayName, type GatewaySession } from "@/lib/gateway/session-utils";
-import { isSessionHidden, hideSession } from "@/lib/gateway/hidden-sessions";
+import { isSessionHidden, hideSession, unhideSession, getHiddenSessions } from "@/lib/gateway/hidden-sessions";
 import { TaskMemo } from "./task-memo";
 import { SessionSettings } from "@/components/settings/session-settings";
 import { ChatHeader } from "./chat-header";
@@ -177,6 +177,46 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
         const delta = matchesShortcutId(e, "prev-session-bracket") ? -1 : 1;
         const nextIdx = (currentIdx + delta + agentSessions.length) % agentSessions.length;
         setSessionKey(agentSessions[nextIdx].key);
+        return;
+      }
+      // Cmd+W: close (hide) current tab
+      if (matchesShortcutId(e, "close-tab")) {
+        if (effectiveSessionKey) {
+          const p = parseSessionKey(effectiveSessionKey);
+          if (p.type !== "main") {
+            e.preventDefault();
+            hideSession(effectiveSessionKey);
+            handleHide(effectiveSessionKey);
+            // Switch to previous tab
+            const currentIdx = agentSessions.findIndex((s) => s.key === effectiveSessionKey);
+            const nextIdx = currentIdx > 0 ? currentIdx - 1 : 0;
+            if (agentSessions[nextIdx]) {
+              setSessionKey(agentSessions[nextIdx].key);
+            } else {
+              setSessionKey(undefined);
+            }
+            return;
+          }
+        }
+        // Don't preventDefault for main — let Electron close the window
+        return;
+      }
+      // Cmd+Shift+T: reopen last hidden session
+      if (matchesShortcutId(e, "reopen-tab")) {
+        e.preventDefault();
+        const hidden = getHiddenSessions();
+        // Find most recently hidden session for this agent
+        const hiddenForAgent = agentSessions.length > 0
+          ? Array.from(hidden).filter((k) => parseSessionKey(k).agentId === agentId)
+          : Array.from(hidden);
+        // Unhide the last one (most recently added)
+        const lastHidden = hiddenForAgent[hiddenForAgent.length - 1];
+        if (lastHidden) {
+          unhideSession(lastHidden);
+          setHiddenVersion((v) => v + 1);
+          setSessionKey(lastHidden);
+          refreshSessions();
+        }
         return;
       }
       // '/' — focus chat input (only when not already in an input/textarea)

--- a/apps/web/src/components/chat/message-list.tsx
+++ b/apps/web/src/components/chat/message-list.tsx
@@ -563,7 +563,7 @@ function SessionBoundary({
               className="flex items-center gap-1 rounded-md border border-zinc-600/30 bg-zinc-800/40 px-2.5 py-1 text-[10px] text-zinc-400 transition hover:bg-zinc-700/40 hover:text-zinc-300"
             >
               <History size={10} />
-              이전 세션 보기
+              이전 대화 보기
             </button>
           )}
         </div>

--- a/apps/web/src/components/chat/session-manager-panel.tsx
+++ b/apps/web/src/components/chat/session-manager-panel.tsx
@@ -5,6 +5,7 @@ import {
   Trash2, RotateCcw, X, ChevronDown, ChevronRight,
 } from "lucide-react";
 import { parseSessionKey, type GatewaySession } from "@/lib/gateway/session-utils";
+import { getHiddenSessions, unhideSession } from "@/lib/gateway/hidden-sessions";
 import type { Agent } from "@/lib/gateway/protocol";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
 import { cn } from "@/lib/utils";
@@ -297,6 +298,38 @@ export function SessionManagerPanel({
           {groups.length === 0 && (
             <div className="py-12 text-center text-sm text-zinc-500">세션 없음</div>
           )}
+
+          {/* Hidden sessions */}
+          {(() => {
+            const hidden = getHiddenSessions();
+            const hiddenKeys = Array.from(hidden);
+            if (hiddenKeys.length === 0) return null;
+            return (
+              <div className="border-t border-zinc-700/50 mt-2 pt-2">
+                <div className="px-4 py-2 text-[11px] font-medium text-zinc-500 uppercase tracking-wide">
+                  숨긴 세션 ({hiddenKeys.length}개)
+                </div>
+                {hiddenKeys.map((key) => {
+                  const p = parseSessionKey(key);
+                  return (
+                    <div key={key} className="flex items-center gap-2 px-4 pl-6 py-1.5 hover:bg-zinc-800/30 transition group">
+                      <span className="text-[11px] text-zinc-500 truncate flex-1">{key}</span>
+                      <button
+                        onClick={() => {
+                          unhideSession(key);
+                          onSelectSession(key);
+                          onClose();
+                        }}
+                        className="rounded px-2 py-0.5 text-[10px] text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200 transition opacity-0 group-hover:opacity-100"
+                      >
+                        다시 열기
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })()}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/chat/topic-history.tsx
+++ b/apps/web/src/components/chat/topic-history.tsx
@@ -87,7 +87,7 @@ export function TopicHistory({ sessionKey, open, onClose, portalContainer }: Top
         {/* Header */}
         <div className="flex items-center gap-2 border-b border-border px-4 py-3">
           <History size={16} className="text-amber-400" />
-          <span className="text-sm font-semibold text-foreground">세션 이력</span>
+          <span className="text-sm font-semibold text-foreground">대화 이력</span>
           <span className="text-xs text-muted-foreground ml-1">({entries.length}개)</span>
           <div className="flex-1" />
           <button onClick={onClose} className="rounded p-1 text-muted-foreground hover:text-foreground transition">
@@ -101,7 +101,7 @@ export function TopicHistory({ sessionKey, open, onClose, portalContainer }: Top
             <p className="text-center text-sm text-muted-foreground py-8">불러오는 중...</p>
           )}
           {!loading && entries.length === 0 && (
-            <p className="text-center text-sm text-muted-foreground py-8">이전 세션 이력이 없습니다</p>
+            <p className="text-center text-sm text-muted-foreground py-8">이전 대화 이력이 없습니다</p>
           )}
           {!loading && entries.length > 0 && (
             <div className="space-y-3">
@@ -115,7 +115,7 @@ export function TopicHistory({ sessionKey, open, onClose, portalContainer }: Top
                     {idx > 0 && (
                       <div className="flex items-center gap-2 py-2">
                         <div className="flex-1 border-t border-dashed border-zinc-700/50" />
-                        <span className="text-[10px] text-amber-500/60 font-medium">세션 갱신</span>
+                        <span className="text-[10px] text-amber-500/60 font-medium">대화 리셋</span>
                         <div className="flex-1 border-t border-dashed border-zinc-700/50" />
                       </div>
                     )}
@@ -139,7 +139,7 @@ export function TopicHistory({ sessionKey, open, onClose, portalContainer }: Top
                           "text-xs font-medium",
                           isCurrent ? "text-amber-300" : "text-zinc-400"
                         )}>
-                          {isCurrent ? "현재 세션" : `이전 세션 #${entries.length - idx}`}
+                          {isCurrent ? "현재 대화" : `이전 대화 #${entries.length - idx}`}
                         </span>
                         <div className="flex-1" />
                         <span className="text-[10px] text-muted-foreground">

--- a/apps/web/src/lib/shortcuts.ts
+++ b/apps/web/src/lib/shortcuts.ts
@@ -30,6 +30,8 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
   { id: "session-switcher", keys: isMac ? "Cmd+K" : "Ctrl+K", description: "세션 스위처 열기", scope: "panel" },
   { id: "agent-browser", keys: isMac ? "Cmd+O" : "Ctrl+O", description: "에이전트별 세션 브라우저", scope: "panel" },
   { id: "new-tab", keys: isMac ? "Cmd+T" : "Ctrl+T", description: "새 탭 열기 (세션 생성)", scope: "panel" },
+  { id: "close-tab", keys: isMac ? "Cmd+W" : "Ctrl+W", description: "현재 탭 닫기 (숨기기)", scope: "panel" },
+  { id: "reopen-tab", keys: isMac ? "Cmd+Shift+T" : "Ctrl+Shift+T", description: "마지막 닫은 탭 다시 열기", scope: "panel" },
   { id: "switch-tab-1", keys: isMac ? "Cmd+1" : "Alt+1", description: "탭 1로 이동", scope: "panel" },
   { id: "switch-tab-2", keys: isMac ? "Cmd+2" : "Alt+2", description: "탭 2로 이동", scope: "panel" },
   { id: "switch-tab-3", keys: isMac ? "Cmd+3" : "Alt+3", description: "탭 3로 이동", scope: "panel" },


### PR DESCRIPTION
## Changes

### #84 — 세션↔토픽 구조 재설계
- UI 전체에서 '세션 이력' → '대화 이력'으로 리네이밍
- 세션 탭(세션)과 대화 이력(리셋 기록)이 직관적으로 구분되도록 라벨 변경
- '세션 갱신' → '대화 리셋', '현재 세션' → '현재 대화', '이전 세션' → '이전 대화'

### #85 — Cmd+1~0 토픽 이동
- 이미 구현 완료 확인 (Cmd+1~9로 세션 탭 전환, 9=마지막 탭)
- shortcuts.ts의 switch-tab-1~9 + chat-panel.tsx 핸들러 동작 중

### #89 — 세션 닫기 기능
- Cmd+W: 비메인 세션을 삭제가 아닌 숨기기(hide)로 변경
- Cmd+Shift+T: 마지막 숨긴 세션 다시 열기 (reopen-tab 단축키 추가)
- 세션 관리 패널에 '숨긴 세션' 섹션 추가 → 다시 열기 버튼

### #90 — 내용 불명확 이슈
- 구체적 내용 없음 (BRXCE에 '이슈'로만 등록) → Close

## Test
- 빌드 통과 ✅
- 테스트 361/362 통과 (1개 실패는 main 브랜치 기존 이슈 — client.test.ts device identity)

Closes #84, closes #85, closes #89, closes #90