### PR TITLE
feat(desktop): macOS Dock/Cmd+Tab에 iClaw 앱 아이콘 표시 (#125)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, protocol, net, Menu, screen, dialog } from "electron";
+import { app, BrowserWindow, shell, protocol, net, Menu, screen, dialog, nativeImage } from "electron";
 import { join } from "path";
 import { readFileSync, writeFileSync } from "fs";
 
@@ -269,6 +269,17 @@ app.on("render-process-gone", (_event, _webContents, details) => {
 });
 
 app.whenReady().then(() => {
+  // Set Dock icon (macOS) — ensures iClaw icon shows in Dock & Cmd+Tab even in dev mode
+  if (process.platform === "darwin") {
+    const iconPath = join(__dirname, "../../../../resources/icon.png");
+    try {
+      const icon = nativeImage.createFromPath(iconPath);
+      if (!icon.isEmpty()) app.dock.setIcon(icon);
+    } catch (err) {
+      console.warn("[main] Failed to set dock icon:", err);
+    }
+  }
+
   registerProtocol();
   registerIpcHandlers();
 


### PR DESCRIPTION
## 관련 이슈
Closes #125

## 변경 사항
- `nativeImage` import 추가
- `app.whenReady()` 진입 시 `app.dock.setIcon()`으로 `resources/icon.png` 적용
- macOS 전용 (`process.platform === 'darwin'`), 아이콘 로드 실패 시 graceful fallback

## 영향 범위
| 환경 | 동작 |
|---|---|
| 개발 모드 (`dev:electron`) | Dock/Cmd+Tab에 iClaw 아이콘 표시 ✅ |
| 패키징 앱 | `electron-builder`의 `icon.icns` 우선 적용 (변경 없음) ✅ |

## 변경 파일
- `apps/desktop/src/main/index.ts` (+12, -1)