### PR TITLE
fix(shortcuts): Cmd+W closes window, Opt+W closes tab (#133)

### DIFF
--- a/apps/web/src/__tests__/shortcut-system.test.ts
+++ b/apps/web/src/__tests__/shortcut-system.test.ts
@@ -246,7 +246,42 @@ describe("custom bindings", () => {
 });
 
 // ============================================================
-// 5. Shortcut definitions — 전체 shortcut 정의 완전성 검증
+// 5. close-tab → Opt+W / Alt+W (#133: Cmd+W should close window, not tab)
+// ============================================================
+
+describe("close-tab shortcut (#133)", () => {
+  it("close-tab is mapped to Opt+W (Mac) or Alt+W (non-Mac), NOT Cmd+W/Ctrl+W", () => {
+    const closeTab = DEFAULT_SHORTCUTS.find((s) => s.id === "close-tab");
+    expect(closeTab).toBeDefined();
+    // In jsdom (non-Mac): should be Alt+W
+    // On Mac: should be Opt+W
+    if (isMacEnv) {
+      expect(closeTab!.keys).toBe("Opt+W");
+    } else {
+      expect(closeTab!.keys).toBe("Alt+W");
+    }
+  });
+
+  it("Alt+W matches close-tab (non-Mac env)", () => {
+    if (isMacEnv) return; // skip on Mac
+    const e = createKeyboardEvent("w", { altKey: true });
+    expect(matchesShortcutId(e, "close-tab")).toBe(true);
+  });
+
+  it("Ctrl+W does NOT match close-tab (non-Mac env)", () => {
+    if (isMacEnv) return;
+    const e = createKeyboardEvent("w", { ctrlKey: true });
+    expect(matchesShortcutId(e, "close-tab")).toBe(false);
+  });
+
+  it("Cmd+W does NOT match close-tab on any platform", () => {
+    const e = createKeyboardEvent("w", { metaKey: true });
+    expect(matchesShortcutId(e, "close-tab")).toBe(false);
+  });
+});
+
+// ============================================================
+// 6. Shortcut definitions — 전체 shortcut 정의 완전성 검증
 // ============================================================
 
 describe("shortcut definitions completeness", () => {

--- a/apps/web/src/lib/shortcuts.ts
+++ b/apps/web/src/lib/shortcuts.ts
@@ -29,7 +29,7 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
   { id: "session-switcher", keys: isMac ? "Cmd+K" : "Ctrl+K", description: "세션 스위처 열기", scope: "panel" },
   { id: "agent-browser", keys: isMac ? "Cmd+O" : "Ctrl+O", description: "에이전트별 세션 브라우저", scope: "panel" },
   { id: "new-tab", keys: isMac ? "Cmd+T" : "Ctrl+T", description: "새 탭 열기 (세션 생성)", scope: "panel" },
-  { id: "close-tab", keys: isMac ? "Cmd+W" : "Ctrl+W", description: "현재 탭 닫기 (숨기기)", scope: "panel" },
+  { id: "close-tab", keys: isMac ? "Opt+W" : "Alt+W", description: "현재 탭 닫기 (숨기기)", scope: "panel" },
   { id: "reopen-tab", keys: isMac ? "Cmd+Shift+T" : "Ctrl+Shift+T", description: "마지막 닫은 탭 다시 열기", scope: "panel" },
   { id: "switch-tab-1", keys: isMac ? "Cmd+1" : "Alt+1", description: "탭 1로 이동", scope: "panel" },
   { id: "switch-tab-2", keys: isMac ? "Cmd+2" : "Alt+2", description: "탭 2로 이동", scope: "panel" },


### PR DESCRIPTION
## Summary
Closes #133

### Problem
`Cmd+W` was mapped to **close (hide) session tab**, conflicting with macOS/Electron standard behavior (close window).

### Changes
| Platform | Close Tab (Session) | Close Window |
|----------|-------------------|--------------|
| **Mac** | `Opt+W` | `Cmd+W` (Electron native) |
| **Windows** | `Alt+W` | `Ctrl+W` (Electron native) |

### Modified Files
- `apps/web/src/lib/shortcuts.ts` — `close-tab` keybinding changed
- `apps/web/src/__tests__/shortcut-system.test.ts` — TDD tests added

### Testing
- 36/36 tests pass (vitest)
- `Cmd+W` no longer intercepted by renderer → Electron `{ role: 'close' }` handles window close
- No Electron main process changes required