### PR TITLE
fix(chat): prevent message drop during new-session switch race (#50)

### DIFF
--- a/apps/web/src/__tests__/hooks-useChat-integration.test.tsx
+++ b/apps/web/src/__tests__/hooks-useChat-integration.test.tsx
@@ -195,6 +195,48 @@ describe("useChat integration", () => {
     expect(result.current.agentStatus.phase).toBe("idle");
   });
 
+  it("retries chat.send once and uses latest sessionKey during session switch (Issue #50)", async () => {
+    let sessionKey = "test:agent-1";
+    const { result, rerender } = renderHook(() => useChat(sessionKey));
+    await act(async () => { vi.advanceTimersByTime(200); });
+
+    let sendAttempt = 0;
+    mockClient!.request.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "chat.history") return { messages: [] };
+      if (method === "chat.send") {
+        sendAttempt++;
+        if (sendAttempt === 1) {
+          throw new Error("Session bootstrap in progress");
+        }
+        return { ok: true, params };
+      }
+      return {};
+    });
+
+    // Send while old session is active
+    act(() => { result.current.sendMessage("send-through-switch"); });
+
+    // Simulate immediate new-session switch right after user send
+    sessionKey = "test:agent-2";
+    rerender();
+
+    // Run retry timer + pending microtasks
+    await act(async () => {
+      await Promise.resolve();
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    const sendCalls = mockClient!.request.mock.calls.filter((c) => c[0] === "chat.send");
+    expect(sendCalls.length).toBe(2);
+
+    // First send used old key, retry should follow latest session key
+    expect(sendCalls[0][1]).toMatchObject({ sessionKey: "test:agent-1" });
+    expect(sendCalls[1][1]).toMatchObject({ sessionKey: "test:agent-2" });
+  });
+
   it("subsequent loadHistory does NOT show loading (Bug #1 regression)", async () => {
     mockClient!.request.mockResolvedValue({
       messages: [

--- a/apps/web/src/lib/gateway/hooks.tsx
+++ b/apps/web/src/lib/gateway/hooks.tsx
@@ -1527,19 +1527,34 @@ export function useChat(sessionKey?: string) {
       setStreaming(true);
       startStreamingTimeout();
       setAgentStatusDebug({ phase: "thinking" });
-      try {
-        await client.request("chat.send", {
-          message: text,
-          idempotencyKey: `awf-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-          sessionKey,
-        });
-      } catch (err) {
-        console.error("[AWF] chat.send error:", String(err));
-        clearStreamingTimeout();
-        setStreaming(false);
+
+      const idempotencyKey = `awf-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const maxAttempts = 2; // initial + one retry for session bootstrap race (#50)
+
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          await client.request("chat.send", {
+            message: text,
+            idempotencyKey,
+            // Use the latest session key on retry to avoid new-session race (#50)
+            sessionKey: sessionKeyRef.current || sessionKey,
+          });
+          return;
+        } catch (err) {
+          const isLast = attempt >= maxAttempts;
+          if (isLast) {
+            console.error("[AWF] chat.send error:", String(err));
+            clearStreamingTimeout();
+            setStreaming(false);
+            setAgentStatusDebug({ phase: "idle" });
+            return;
+          }
+          // Short retry window for immediate session-switch/bootstrap timing race.
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        }
       }
     },
-    [client, state, sessionKey]
+    [client, state, sessionKey, startStreamingTimeout, clearStreamingTimeout, setAgentStatusDebug]
   );
 
   const processQueue = useCallback(async () => {


### PR DESCRIPTION
## Summary
- add one-shot retry for `chat.send` to absorb session-bootstrap timing race
- retry reuses the same idempotency key to avoid duplicates
- retry targets latest `sessionKeyRef.current` so immediate new-session switch is respected
- keep UI status sane on final failure (`streaming=false`, `agentStatus=idle`)

## TDD
- added integration test in `hooks-useChat-integration.test.tsx`
  - `retries chat.send once and uses latest sessionKey during session switch (Issue #50)`
  - verifies first send uses old key, retry uses latest switched key

## Test
- `pnpm --filter @intelli-claw/web exec vitest run src/__tests__/hooks-useChat-integration.test.tsx`
