### PR TITLE
fix(web): session continuity across day/restart (#49)

### DIFF
--- a/apps/web/src/__tests__/session-continuity.test.ts
+++ b/apps/web/src/__tests__/session-continuity.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSessionContinuityKeys,
+  resolveInitialSessionState,
+  getRememberedSessionForAgent,
+} from "@/lib/session-continuity";
+
+describe("session continuity (#49)", () => {
+  it("builds scoped + fallback keys", () => {
+    const keys = buildSessionContinuityKeys({
+      windowPrefix: "w2:",
+      panelId: "panel-1",
+      agentId: "iclaw",
+    });
+
+    expect(keys.scopedSessionKey).toBe("awf:w2:panel:panel-1:sessionKey");
+    expect(keys.scopedAgentKey).toBe("awf:w2:panel:panel-1:agentId");
+    expect(keys.agentRememberedSessionKey).toBe("awf:lastSessionKey:iclaw");
+    expect(keys.legacyPanelSessionKey).toBe("awf:panel:panel-1:sessionKey");
+    expect(keys.legacyGlobalSessionKey).toBe("awf:sessionKey");
+  });
+
+  it("prefers scoped session key when available", () => {
+    const store = new Map<string, string>([
+      ["awf:w1:panel:main:sessionKey", "agent:iclaw:main:thread:scoped"],
+      ["awf:lastSessionKey:iclaw", "agent:iclaw:main:thread:remembered"],
+    ]);
+
+    const state = resolveInitialSessionState({
+      windowPrefix: "w1:",
+      panelId: "main",
+      defaultAgentId: "iclaw",
+      getItem: (k) => store.get(k) ?? null,
+    });
+
+    expect(state.agentId).toBe("iclaw");
+    expect(state.sessionKey).toBe("agent:iclaw:main:thread:scoped");
+  });
+
+  it("falls back to remembered agent session when scoped key missing", () => {
+    const store = new Map<string, string>([
+      ["awf:w1:panel:main:agentId", "iclaw"],
+      ["awf:lastSessionKey:iclaw", "agent:iclaw:main:thread:last"],
+    ]);
+
+    const state = resolveInitialSessionState({
+      windowPrefix: "w1:",
+      panelId: "main",
+      defaultAgentId: "default",
+      getItem: (k) => store.get(k) ?? null,
+    });
+
+    expect(state.agentId).toBe("iclaw");
+    expect(state.sessionKey).toBe("agent:iclaw:main:thread:last");
+  });
+
+  it("falls back to legacy keys when remembered key missing", () => {
+    const store = new Map<string, string>([
+      ["awf:panel:main:sessionKey", "agent:iclaw:main:thread:legacy-panel"],
+    ]);
+
+    const state = resolveInitialSessionState({
+      windowPrefix: "w9:",
+      panelId: "main",
+      defaultAgentId: "iclaw",
+      getItem: (k) => store.get(k) ?? null,
+    });
+
+    expect(state.sessionKey).toBe("agent:iclaw:main:thread:legacy-panel");
+  });
+
+  it("getRememberedSessionForAgent returns null when absent", () => {
+    const remembered = getRememberedSessionForAgent({
+      agentId: "main",
+      getItem: () => null,
+    });
+    expect(remembered).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -21,6 +21,7 @@ import { useSwipeGesture, getNextAgentIndex } from "@/lib/hooks/use-swipe-gestur
 import { NewSessionPicker, AgentManager } from "@/components/settings/agent-manager";
 import { SessionManagerPanel } from "./session-manager-panel";
 import { TopicHistory } from "./topic-history";
+import { resolveInitialSessionState, getRememberedSessionForAgent } from "@/lib/session-continuity";
 
 export interface ChatPanelProps {
   /** Panel id for focus management */
@@ -43,20 +44,31 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
   const [sessionKey, setSessionKeyRaw] = useState<string | undefined>(undefined);
   const [agentId, setAgentId] = useState<string>(import.meta.env.VITE_DEFAULT_AGENT || "default");
 
-  // Load persisted panel state on mount (client only)
+  // Load persisted state on mount (client only)
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const savedSession = localStorage.getItem(`${storagePrefix}sessionKey`) || undefined;
-    const savedAgent = localStorage.getItem(`${storagePrefix}agentId`) || import.meta.env.VITE_DEFAULT_AGENT || "default";
-    setSessionKeyRaw(savedSession);
-    setAgentId(savedAgent);
-  }, [storagePrefix]);
+    const initial = resolveInitialSessionState({
+      windowPrefix: windowStoragePrefix(),
+      panelId,
+      defaultAgentId: import.meta.env.VITE_DEFAULT_AGENT || "default",
+      getItem: (k) => localStorage.getItem(k),
+    });
+    setSessionKeyRaw(initial.sessionKey);
+    setAgentId(initial.agentId);
+  }, [panelId]);
 
   const setSessionKey = useCallback((key: string | undefined) => {
     setSessionKeyRaw(key);
     if (typeof window !== "undefined") {
-      if (key) localStorage.setItem(`${storagePrefix}sessionKey`, key);
-      else localStorage.removeItem(`${storagePrefix}sessionKey`);
+      if (key) {
+        localStorage.setItem(`${storagePrefix}sessionKey`, key);
+        const parsed = parseSessionKey(key);
+        if (parsed.agentId && parsed.agentId !== "unknown") {
+          localStorage.setItem(`awf:lastSessionKey:${parsed.agentId}`, key);
+        }
+      } else {
+        localStorage.removeItem(`${storagePrefix}sessionKey`);
+      }
     }
     // Sync agentId from session key
     if (key) {
@@ -548,6 +560,12 @@ export function ChatPanel({ panelId, isActive, onFocus, showHeader = true }: Cha
     setAgentId(newId);
     if (typeof window !== "undefined") {
       localStorage.setItem(`${storagePrefix}agentId`, newId);
+      const remembered = getRememberedSessionForAgent({
+        agentId: newId,
+        getItem: (k) => localStorage.getItem(k),
+      });
+      setSessionKey(remembered || undefined);
+      return;
     }
     setSessionKey(undefined);
   };

--- a/apps/web/src/lib/session-continuity.ts
+++ b/apps/web/src/lib/session-continuity.ts
@@ -1,0 +1,55 @@
+export interface SessionContinuityKeys {
+  scopedSessionKey: string;
+  scopedAgentKey: string;
+  agentRememberedSessionKey: string;
+  legacyPanelSessionKey: string;
+  legacyGlobalSessionKey: string;
+}
+
+export function buildSessionContinuityKeys(params: {
+  windowPrefix: string;
+  panelId: string;
+  agentId: string;
+}): SessionContinuityKeys {
+  const { windowPrefix, panelId, agentId } = params;
+  const scopedPrefix = `awf:${windowPrefix}panel:${panelId}:`;
+  return {
+    scopedSessionKey: `${scopedPrefix}sessionKey`,
+    scopedAgentKey: `${scopedPrefix}agentId`,
+    agentRememberedSessionKey: `awf:lastSessionKey:${agentId}`,
+    legacyPanelSessionKey: `awf:panel:${panelId}:sessionKey`,
+    legacyGlobalSessionKey: "awf:sessionKey",
+  };
+}
+
+export function resolveInitialSessionState(params: {
+  windowPrefix: string;
+  panelId: string;
+  defaultAgentId: string;
+  getItem: (key: string) => string | null;
+}): { agentId: string; sessionKey?: string } {
+  const { windowPrefix, panelId, defaultAgentId, getItem } = params;
+
+  const scopedPrefix = `awf:${windowPrefix}panel:${panelId}:`;
+  const scopedAgent = getItem(`${scopedPrefix}agentId`);
+  const agentId = scopedAgent || defaultAgentId;
+
+  const keys = buildSessionContinuityKeys({ windowPrefix, panelId, agentId });
+
+  const sessionKey =
+    getItem(keys.scopedSessionKey) ||
+    getItem(keys.agentRememberedSessionKey) ||
+    getItem(keys.legacyPanelSessionKey) ||
+    getItem(keys.legacyGlobalSessionKey) ||
+    undefined;
+
+  return { agentId, sessionKey };
+}
+
+export function getRememberedSessionForAgent(params: {
+  agentId: string;
+  getItem: (key: string) => string | null;
+}): string | null {
+  const { agentId, getItem } = params;
+  return getItem(`awf:lastSessionKey:${agentId}`);
+}


### PR DESCRIPTION
## Summary
Closes #49

다음날/재시작 시 세션이 항상 새로 시작되는 체감 문제를 완화하기 위해,
로컬 세션 복원 로직에 **agent별 마지막 세션 기억(fallback)** 을 추가했습니다.

## Root cause hypothesis
기존 로직은 window+panel 스코프 키(`awf:{window}panel:{id}:sessionKey`)만 우선 복원하여,
해당 키가 없거나 window scope가 바뀐 경우 `agent:{id}:main`으로 떨어졌습니다.
이때 사용자 체감상 "다음날 무조건 새 세션"처럼 보일 수 있습니다.

## Changes

### 1) New utility: `session-continuity.ts`
- `buildSessionContinuityKeys()`
- `resolveInitialSessionState()`
- `getRememberedSessionForAgent()`

복원 우선순위:
1. scoped session key (`awf:{window}panel:{id}:sessionKey`)
2. agent remembered key (`awf:lastSessionKey:{agentId}`)
3. legacy panel key (`awf:panel:{id}:sessionKey`)
4. legacy global key (`awf:sessionKey`)

### 2) `chat-panel.tsx`
- mount 시 `resolveInitialSessionState()`로 초기 agent/session 복원
- `setSessionKey()` 호출 시 `awf:lastSessionKey:{agentId}` 업데이트
- agent 변경 시 해당 agent의 remembered session 복원 시도

### 3) TDD tests
- `session-continuity.test.ts` 추가 (5 tests)
  - 키 생성 검증
  - scoped 우선 복원
  - remembered fallback 복원
  - legacy fallback 복원
  - absent 케이스

## Test results
- `session-continuity.test.ts`: 5/5 pass
- `issue-111-112-session-reset.test.ts`: 14/14 pass (regression check)

## Notes
이 PR은 Gateway의 sessionId reset 정책 자체를 바꾸지 않고,
UI/로컬 복원 레이어에서 세션 연속성을 최대화합니다.
