### PR TITLE
feat(chat): Excalidraw diagram rendering support (#8)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@excalidraw/excalidraw": "0.17.6",
     "@intelli-claw/shared": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/__tests__/excalidraw-support.test.ts
+++ b/apps/web/src/__tests__/excalidraw-support.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  isExcalidrawLanguage,
+  parseExcalidrawJson,
+  isExcalidrawFilePath,
+} from "@/lib/excalidraw";
+
+describe("excalidraw helpers (#8)", () => {
+  it("detects excalidraw language token", () => {
+    expect(isExcalidrawLanguage("excalidraw")).toBe(true);
+    expect(isExcalidrawLanguage("Excalidraw")).toBe(true);
+    expect(isExcalidrawLanguage("json")).toBe(false);
+    expect(isExcalidrawLanguage("")).toBe(false);
+  });
+
+  it("parses valid excalidraw json", () => {
+    const raw = JSON.stringify({
+      type: "excalidraw",
+      version: 2,
+      source: "https://excalidraw.com",
+      elements: [
+        { id: "a", type: "rectangle", x: 10, y: 10, width: 100, height: 80 },
+      ],
+      appState: { viewBackgroundColor: "#ffffff" },
+      files: {},
+    });
+
+    const parsed = parseExcalidrawJson(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.elements.length).toBe(1);
+    expect(parsed?.appState.viewModeEnabled).toBe(true);
+  });
+
+  it("returns null for invalid json", () => {
+    expect(parseExcalidrawJson("{not-json}")).toBeNull();
+  });
+
+  it("returns null when elements are missing", () => {
+    const raw = JSON.stringify({ type: "excalidraw", version: 2 });
+    expect(parseExcalidrawJson(raw)).toBeNull();
+  });
+
+  it("detects .excalidraw file extension", () => {
+    expect(isExcalidrawFilePath("/tmp/diagram.excalidraw")).toBe(true);
+    expect(isExcalidrawFilePath("https://a.com/flow.excalidraw?token=1")).toBe(true);
+    expect(isExcalidrawFilePath("/tmp/diagram.json")).toBe(false);
+  });
+});

--- a/apps/web/src/components/chat/markdown-renderer.tsx
+++ b/apps/web/src/components/chat/markdown-renderer.tsx
@@ -1,5 +1,5 @@
 
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
@@ -12,6 +12,12 @@ import {
 import type { Components } from "react-markdown";
 import { blobDownload, forceDownloadUrl } from "@/lib/utils/download";
 import { platform } from "@/lib/platform";
+import { isExcalidrawLanguage, parseExcalidrawJson, isExcalidrawFilePath } from "@/lib/excalidraw";
+
+const LazyExcalidraw = lazy(async () => {
+  const mod = await import("@excalidraw/excalidraw");
+  return { default: mod.Excalidraw };
+});
 
 function copyText(text: string) {
   if (navigator.clipboard?.writeText) return navigator.clipboard.writeText(text);
@@ -142,6 +148,33 @@ function HtmlPreview({ code }: { code: string }) {
   );
 }
 
+function ExcalidrawBlock({ code, title = "Excalidraw" }: { code: string; title?: string }) {
+  const parsed = useMemo(() => parseExcalidrawJson(code), [code]);
+
+  if (!parsed) {
+    return (
+      <div className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-400">
+        Excalidraw JSON 파싱에 실패했습니다. 아래 코드 원문을 확인해주세요.
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-2 overflow-hidden rounded-lg border border-zinc-700">
+      <div className="bg-zinc-800 px-3 py-1.5 text-xs text-zinc-400">{title}</div>
+      <div style={{ height: 420 }} className="bg-zinc-900">
+        <Suspense fallback={<div className="p-3 text-xs text-zinc-500">다이어그램 로딩 중...</div>}>
+          <LazyExcalidraw
+            initialData={parsed}
+            viewModeEnabled
+            UIOptions={{ canvasActions: { loadScene: false, saveToActiveFile: false } }}
+          />
+        </Suspense>
+      </div>
+    </div>
+  );
+}
+
 function CodeBlock({ className, children, rawChildren }: { className?: string; children: React.ReactNode; rawChildren?: React.ReactNode }) {
   const [copied, setCopied] = useState(false);
   const [showPreview, setShowPreview] = useState(true);
@@ -149,6 +182,7 @@ function CodeBlock({ className, children, rawChildren }: { className?: string; c
   const lang = rawLang.split(/\s+/)[0] || "";
   const code = extractText(rawChildren ?? children).replace(/\n$/, "");
   const isHtml = (lang === "html" || lang === "xml" || code.trimStart().startsWith("<!") || code.trimStart().startsWith("<html")) && code.includes("<");
+  const isExcalidraw = isExcalidrawLanguage(lang);
 
   const handleCopy = useCallback(async () => {
     try {
@@ -188,12 +222,16 @@ function CodeBlock({ className, children, rawChildren }: { className?: string; c
           )}
         </button>
       </div>
-      {(!isHtml || !showPreview) && (
-        <pre className="!mt-0 !rounded-t-none">
-          <code className={className}>{children}</code>
-        </pre>
+      {isExcalidraw ? (
+        <ExcalidrawBlock code={code} />
+      ) : (
+        (!isHtml || !showPreview) && (
+          <pre className="!mt-0 !rounded-t-none">
+            <code className={className}>{children}</code>
+          </pre>
+        )
       )}
-      {isHtml && (
+      {isHtml && !isExcalidraw && (
         <>
           <div className="flex border-t border-zinc-700">
             <button
@@ -277,7 +315,7 @@ const components: Partial<Components> = {
 
 // ---- Media file type detection ----
 
-type MediaType = "image" | "video" | "audio" | "pdf" | "code" | "text" | "spreadsheet" | "archive" | "other";
+type MediaType = "image" | "video" | "audio" | "pdf" | "code" | "text" | "spreadsheet" | "archive" | "excalidraw" | "other";
 
 const IMAGE_EXTS = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "ico", "bmp", "tiff", "tif"]);
 const VIDEO_EXTS = new Set(["mp4", "webm", "mov", "avi", "mkv"]);
@@ -292,6 +330,7 @@ function getExtension(path: string): string {
 }
 
 function detectMediaType(path: string): MediaType {
+  if (isExcalidrawFilePath(path)) return "excalidraw";
   const ext = getExtension(path);
   if (IMAGE_EXTS.has(ext)) return "image";
   if (VIDEO_EXTS.has(ext)) return "video";
@@ -322,6 +361,7 @@ function renderMediaTypeIcon(type: MediaType, size: number) {
     case "spreadsheet": return <FileSpreadsheet size={size} />;
     case "archive": return <FileArchive size={size} />;
     case "text": return <FileText size={size} />;
+    case "excalidraw": return <FileCode size={size} />;
     default: return <FileIcon size={size} />;
   }
 }
@@ -500,8 +540,35 @@ function getMediaAccent(type: MediaType): string {
     case "spreadsheet": return "bg-emerald-500/20 text-emerald-400";
     case "archive": return "bg-yellow-500/20 text-yellow-400";
     case "code": return "bg-cyan-500/20 text-cyan-400";
+    case "excalidraw": return "bg-orange-500/20 text-orange-400";
     default: return "bg-zinc-500/20 text-zinc-400";
   }
+}
+
+function ExcalidrawFilePreview({ src, fileName }: { src: string; fileName: string }) {
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch(src)
+      .then((r) => (r.ok ? r.text() : Promise.reject(new Error(`${r.status}`))))
+      .then(setContent)
+      .catch(() => setError(true));
+  }, [src]);
+
+  if (error) {
+    return <FileCard url={src} fileName={fileName} type="excalidraw" />;
+  }
+
+  if (content === null) {
+    return (
+      <div className="rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-500">
+        Excalidraw 파일 로딩 중...
+      </div>
+    );
+  }
+
+  return <ExcalidrawBlock code={content} title={fileName} />;
 }
 
 /** Inline markdown file preview — fetches .md content and renders with MarkdownRenderer */
@@ -609,6 +676,8 @@ function MediaRenderer({ entry }: { entry: MediaEntry }) {
       return <MediaAudio src={entry.url} fileName={entry.fileName} />;
     case "pdf":
       return <MediaPdf src={entry.url} fileName={entry.fileName} />;
+    case "excalidraw":
+      return <ExcalidrawFilePreview src={entry.url} fileName={entry.fileName} />;
     case "text": {
       const ext = getExtension(entry.fileName);
       if (ext === "md" || ext === "mdx") {

--- a/apps/web/src/lib/excalidraw.ts
+++ b/apps/web/src/lib/excalidraw.ts
@@ -1,0 +1,35 @@
+export interface ExcalidrawInitialData {
+  elements: Record<string, unknown>[];
+  appState?: Record<string, unknown>;
+  files?: Record<string, unknown>;
+}
+
+export function isExcalidrawLanguage(lang: string): boolean {
+  return lang.trim().toLowerCase() === "excalidraw";
+}
+
+export function isExcalidrawFilePath(path: string): boolean {
+  return /\.excalidraw(?:\?|$)/i.test(path);
+}
+
+export function parseExcalidrawJson(raw: string): ExcalidrawInitialData | null {
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const elements = parsed.elements;
+    if (!Array.isArray(elements)) return null;
+
+    const appState = (parsed.appState || {}) as Record<string, unknown>;
+    const files = (parsed.files || {}) as Record<string, unknown>;
+
+    return {
+      elements: elements as Record<string, unknown>[],
+      appState: {
+        ...appState,
+        viewModeEnabled: true,
+      },
+      files,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@excalidraw/excalidraw':
+        specifier: 0.17.6
+        version: 0.17.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@intelli-claw/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -1337,6 +1340,12 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@excalidraw/excalidraw@0.17.6':
+    resolution: {integrity: sha512-fyCl+zG/Z5yhHDh5Fq2ZGmphcrALmuOdtITm8gN4d8w4ntnaopTXcTfnAAaU3VleDC6LhTkoLOTG6P5kgREiIg==}
+    peerDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0
 
   '@exodus/bytes@1.14.1':
     resolution: {integrity: sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==}
@@ -8762,6 +8771,11 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@excalidraw/excalidraw@0.17.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   '@exodus/bytes@1.14.1(@noble/hashes@1.8.0)':
     optionalDependencies:


### PR DESCRIPTION
## Summary
Closes #8

응답 내 Excalidraw 콘텐츠를 채팅 UI에서 직접 렌더링하도록 구현했습니다.
- 코드 펜스: ` ```excalidraw ` JSON
- MEDIA 프로토콜: `MEDIA:/path/to/file.excalidraw`

## Why this design (performance-safe)
대용량 라이브러리(`@excalidraw/excalidraw`)가 기본 번들에 상시 로드되지 않도록
`React.lazy` + `Suspense`로 지연 로딩 처리했습니다.

### 성능/안정성 포인트
1. **Lazy load**: Excalidraw는 실제 다이어그램이 있을 때만 로드
2. **Read-only mode**: `viewModeEnabled`로 편집 기능 비활성화
3. **안전 파싱**: JSON 파싱 실패 시 null 처리 + fallback 안내
4. **회귀 방지**: 기존 media/markdown 테스트 재실행

## Changes

### New
- `apps/web/src/lib/excalidraw.ts`
  - `isExcalidrawLanguage()`
  - `isExcalidrawFilePath()`
  - `parseExcalidrawJson()`

- `apps/web/src/__tests__/excalidraw-support.test.ts` (TDD)
  - 언어 감지
  - 유효/무효 JSON 파싱
  - `.excalidraw` 파일 경로 감지

### Updated
- `apps/web/src/components/chat/markdown-renderer.tsx`
  - `CodeBlock`에서 `excalidraw` 언어 감지 시 다이어그램 렌더
  - `MEDIA:` 타입에 `excalidraw` 추가
  - `.excalidraw` 파일 fetch 후 읽기전용 렌더

- `apps/web/package.json`
  - `@excalidraw/excalidraw` 의존성 추가

## Tests
- `excalidraw-support.test.ts`: 5/5 ✅
- `media-protocol.test.ts`: 22/22 ✅
- `markdown-preview.test.ts`: 23/23 ✅
- production build ✅ (`pnpm run build`)

## Notes
이 PR은 UI 렌더링 레이어 변경이며, Gateway/세션 로직에는 영향이 없습니다.
