### PR TITLE
fix(shared): Expo Go(RN) window.addEventListener 크래시 방지

### DIFF
--- a/apps/web/src/__tests__/issue-rn-window-addEventListener.test.ts
+++ b/apps/web/src/__tests__/issue-rn-window-addEventListener.test.ts
@@ -1,0 +1,115 @@
+/**
+ * React Native 환경에서 window.addEventListener가 존재하지 않아
+ * client.ts setupNetworkListeners()에서 크래시 발생하는 이슈.
+ *
+ * RN에서는 `typeof window !== "undefined"` → true이지만
+ * `window.addEventListener`는 undefined.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GatewayClient } from "@/lib/gateway/client";
+
+// --- Mock WebSocket ---
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  readyState = MockWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: ((e: { code?: number; reason?: string; wasClean?: boolean }) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn();
+}
+
+describe("React Native: window.addEventListener 미존재 환경", () => {
+  let originalWebSocket: typeof globalThis.WebSocket;
+  let origAddEventListener: typeof window.addEventListener;
+  let origRemoveEventListener: typeof window.removeEventListener;
+
+  beforeEach(() => {
+    originalWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+    // Restore addEventListener/removeEventListener
+    if (origAddEventListener) {
+      Object.defineProperty(window, "addEventListener", {
+        value: origAddEventListener,
+        writable: true,
+        configurable: true,
+      });
+    }
+    if (origRemoveEventListener) {
+      Object.defineProperty(window, "removeEventListener", {
+        value: origRemoveEventListener,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it("window.addEventListener이 undefined여도 connect()가 크래시하지 않아야 함", () => {
+    // Save originals
+    origAddEventListener = window.addEventListener;
+    origRemoveEventListener = window.removeEventListener;
+
+    // Simulate React Native: window exists but addEventListener is undefined
+    Object.defineProperty(window, "addEventListener", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, "removeEventListener", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const client = new GatewayClient({
+      url: "ws://localhost:18789",
+      token: "test",
+      clientId: "test-rn",
+    });
+
+    // connect() 호출 시 크래시 없이 정상 동작해야 함
+    expect(() => client.connect()).not.toThrow();
+
+    // cleanup도 크래시 없이 동작해야 함
+    expect(() => client.disconnect()).not.toThrow();
+  });
+
+  it("window.addEventListener이 존재하면 정상적으로 리스너를 등록해야 함", () => {
+    const addSpy = vi.fn();
+    const removeSpy = vi.fn();
+
+    origAddEventListener = window.addEventListener;
+    origRemoveEventListener = window.removeEventListener;
+
+    Object.defineProperty(window, "addEventListener", {
+      value: addSpy,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, "removeEventListener", {
+      value: removeSpy,
+      writable: true,
+      configurable: true,
+    });
+
+    const client = new GatewayClient({
+      url: "ws://localhost:18789",
+      token: "test",
+      clientId: "test-browser",
+    });
+
+    client.connect();
+    expect(addSpy).toHaveBeenCalledWith("online", expect.any(Function));
+
+    client.disconnect();
+    expect(removeSpy).toHaveBeenCalledWith("online", expect.any(Function));
+  });
+});

--- a/packages/shared/src/gateway/client.ts
+++ b/packages/shared/src/gateway/client.ts
@@ -403,15 +403,17 @@ export class GatewayClient {
         }
       }
     };
-    if (typeof window !== "undefined") {
+    const hasWindowEvents = typeof window !== "undefined" && typeof window.addEventListener === "function";
+    const hasDocumentEvents = typeof document !== "undefined" && typeof document.addEventListener === "function";
+    if (hasWindowEvents) {
       window.addEventListener("online", handleOnline);
     }
-    if (typeof document !== "undefined") {
+    if (hasDocumentEvents) {
       document.addEventListener("visibilitychange", handleVisibility);
     }
     this.networkCleanup = () => {
-      if (typeof window !== "undefined") window.removeEventListener("online", handleOnline);
-      if (typeof document !== "undefined") document.removeEventListener("visibilitychange", handleVisibility);
+      if (hasWindowEvents) window.removeEventListener("online", handleOnline);
+      if (hasDocumentEvents) document.removeEventListener("visibilitychange", handleVisibility);
     };
   }
 
@@ -448,11 +450,11 @@ export class GatewayClient {
 
   private addBrowserListeners(): void {
     if (this.browserListenersAdded) return;
-    if (typeof window !== "undefined") {
+    if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
       window.addEventListener("online", this.handleOnline);
       window.addEventListener("offline", () => {}); // reserved for future offline handling
     }
-    if (typeof document !== "undefined") {
+    if (typeof document !== "undefined" && typeof document.addEventListener === "function") {
       document.addEventListener("visibilitychange", this.handleVisibilityChange);
     }
     this.browserListenersAdded = true;
@@ -460,10 +462,10 @@ export class GatewayClient {
 
   private removeBrowserListeners(): void {
     if (!this.browserListenersAdded) return;
-    if (typeof window !== "undefined") {
+    if (typeof window !== "undefined" && typeof window.removeEventListener === "function") {
       window.removeEventListener("online", this.handleOnline);
     }
-    if (typeof document !== "undefined") {
+    if (typeof document !== "undefined" && typeof document.removeEventListener === "function") {
       document.removeEventListener("visibilitychange", this.handleVisibilityChange);
     }
     this.browserListenersAdded = false;


### PR DESCRIPTION
## Issue
Closes #146

## 문제
Expo Go(React Native)에서 앱 진입 시 아래 에러로 크래시:

```
window.addEventListener is not a function
```

원인: RN은 `window` 객체는 존재하지만 브라우저의 `addEventListener/removeEventListener` API를 보장하지 않음.

## 변경 내용
- `packages/shared/src/gateway/client.ts`
  - `setupNetworkListeners()`에 브라우저 이벤트 API 존재 여부 가드 추가
  - `addBrowserListeners()/removeBrowserListeners()`에도 동일 가드 적용
- `apps/web/src/__tests__/issue-rn-window-addEventListener.test.ts`
  - RN 시뮬레이션(window 존재, add/removeEventListener 없음)에서 크래시 방지 테스트 추가
  - 브라우저 환경에서는 리스너 등록/해제 정상 동작 검증

## 테스트
```
apps/web
Test Files: 52 passed
Tests:      872 passed
```