### PR TITLE
feat(mobile): swipe-based agent chat navigation (#151)

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,289 +1,176 @@
-import React, { useState, useRef, useCallback, useEffect, useMemo } from "react";
+import React, { useState, useRef, useCallback, useEffect } from "react";
 import {
   View,
   Text,
   Pressable,
-  FlatList,
-  KeyboardAvoidingView,
-  Platform,
-  ActivityIndicator,
   StyleSheet,
   Modal,
-  Keyboard,
+  ActivityIndicator,
 } from "react-native";
+import PagerView from "react-native-pager-view";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Bot, ChevronDown } from "lucide-react-native";
-import { useGateway, parseSessionKey } from "@intelli-claw/shared";
+import { Bot } from "lucide-react-native";
+import { useGateway, useAgents, parseSessionKey } from "@intelli-claw/shared";
 import SettingsScreen from "../../src/components/SettingsScreen";
-import { useChat, type DisplayMessage } from "../../src/hooks/useChat";
 import { useSessionStore } from "../../src/stores/sessionStore";
 import { useSessions } from "../../src/hooks/useSessions";
-import { AttachmentPreview, useFileAttachments } from "../../src/components/FileAttachments";
 import { SessionSwitcher } from "../../src/components/SessionSwitcher";
 import { AgentSelector } from "../../src/components/AgentSelector";
-import { SlashCommands, shouldShowSlashPicker } from "../../src/components/SlashCommands";
 import { SkillPicker } from "../../src/components/SkillPicker";
 
-// Chat components (redesigned)
-import {
-  MessageBubble,
-  EmptyState,
-  AgentStatusBar,
-  InputBar,
-  ScrollToBottomButton,
-  AppBar,
-} from "../../src/components/chat";
+import { AppBar, AgentChatPage } from "../../src/components/chat";
+import { AgentTabBar } from "../../src/components/chat/AgentTabBar";
 
-
-// ─── Chat Screen ───
+// ─── Chat Screen (PagerView-based) ───
 
 export default function ChatScreen() {
   const insets = useSafeAreaInsets();
   const { state, mainSessionKey } = useGateway();
-  const { activeSessionKey, setActiveSessionKey } = useSessionStore();
+  const { setActiveSessionKey } = useSessionStore();
+  const { agents, loading: agentsLoading } = useAgents();
+  const { sessions, loading: sessionsLoading, refresh: refreshSessions } = useSessions();
 
-  const [selectedAgentId, setSelectedAgentId] = useState<string | undefined>();
+  // ─── PagerView ───
+  const pagerRef = useRef<PagerView>(null);
+  const [activePageIndex, setActivePageIndex] = useState(0);
 
-  // Compute effective session key: explicit session > agent-based main > gateway default
-  const effectiveSessionKey = useMemo(() => {
-    if (activeSessionKey) return activeSessionKey;
-    if (selectedAgentId) return `agent:${selectedAgentId}:main`;
-    return mainSessionKey || undefined;
-  }, [activeSessionKey, selectedAgentId, mainSessionKey]);
+  // ─── Per-agent sessionKey overrides ───
+  // Default: `agent:{agentId}:main`. SessionSwitcher can override per agent.
+  const [sessionKeyOverrides, setSessionKeyOverrides] = useState<Map<string, string>>(new Map());
 
-  // Sync selectedAgentId from the current session key
+  // ─── Modal states ───
+  const [sessionPickerOpen, setSessionPickerOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [agentSelectorOpen, setAgentSelectorOpen] = useState(false);
+  const [skillPickerOpen, setSkillPickerOpen] = useState(false);
+
+  // ─── Derived state ───
+  const activeAgent = agents[activePageIndex];
+  const activeAgentId = activeAgent?.id;
+
+  const getSessionKeyForAgent = useCallback(
+    (agentId: string | undefined): string | undefined => {
+      if (!agentId) return undefined;
+      return sessionKeyOverrides.get(agentId) || `agent:${agentId}:main`;
+    },
+    [sessionKeyOverrides],
+  );
+
+  const effectiveSessionKey = getSessionKeyForAgent(activeAgentId);
+
+  // Sync sessionStore's activeSessionKey so other parts of the app stay aware
   useEffect(() => {
-    if (!effectiveSessionKey) return;
-    const p = parseSessionKey(effectiveSessionKey);
-    if (p.agentId && p.agentId !== "unknown" && p.agentId !== selectedAgentId) {
-      setSelectedAgentId(p.agentId);
-    }
-  }, [effectiveSessionKey]); // eslint-disable-line react-hooks/exhaustive-deps
+    setActiveSessionKey(effectiveSessionKey || null);
+  }, [effectiveSessionKey, setActiveSessionKey]);
 
+  // ─── AppBar labels ───
   const parsed = effectiveSessionKey ? parseSessionKey(effectiveSessionKey) : null;
-  const agentLabel = parsed?.agentId || "Chat";
+  const agentLabel = activeAgent?.name || activeAgent?.id || "Chat";
   const sessionLabel = parsed
     ? parsed.type === "main" ? "main" : parsed.detail || parsed.type
     : "";
 
-  const { messages, streaming, loading, agentStatus, sendMessage, abort } = useChat(effectiveSessionKey);
-  const { sessions, loading: sessionsLoading, refresh: refreshSessions } = useSessions();
-
-  const [text, setText] = useState("");
-  const [sessionPickerOpen, setSessionPickerOpen] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const { attachments, addAttachments, removeAttachment, clearAttachments, toPayloads, imageUris: getImageUris } = useFileAttachments();
-  const [agentSelectorOpen, setAgentSelectorOpen] = useState(false);
-  const [skillPickerOpen, setSkillPickerOpen] = useState(false);
-  const showSlashPicker = shouldShowSlashPicker(text);
-  const flatListRef = useRef<FlatList>(null);
-  const [userScrolledUp, setUserScrolledUp] = useState(false);
-  const isAtBottomRef = useRef(true);
-  const [keyboardVisible, setKeyboardVisible] = useState(false);
-
-  useEffect(() => {
-    const showSub = Keyboard.addListener("keyboardWillShow", () => setKeyboardVisible(true));
-    const hideSub = Keyboard.addListener("keyboardWillHide", () => setKeyboardVisible(false));
-    return () => { showSub.remove(); hideSub.remove(); };
-  }, []);
-
-  // ─── Smart auto-scroll ───
-  const handleScroll = useCallback((e: any) => {
-    const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
-    const atBottom = contentOffset.y + layoutMeasurement.height >= contentSize.height - 80;
-    isAtBottomRef.current = atBottom;
-    setUserScrolledUp(!atBottom);
-  }, []);
-
-  useEffect(() => {
-    if (isAtBottomRef.current && flatListRef.current) {
-      flatListRef.current.scrollToEnd({ animated: true });
-    }
-  }, [messages.length, streaming]);
-
-  const scrollToBottom = useCallback(() => {
-    flatListRef.current?.scrollToEnd({ animated: true });
-    setUserScrolledUp(false);
-    isAtBottomRef.current = true;
-  }, []);
-
-  // ─── Slash command handler ───
-  const handleSlashSelect = useCallback(
-    (command: string, immediate?: boolean) => {
-      if (immediate) {
-        if (command === "/stop") {
-          abort();
-        } else if (command === "/new") {
-          setActiveSessionKey(null);
-        } else if (command === "/reset") {
-          sendMessage(command);
-        } else {
-          sendMessage(command);
-        }
-        setText("");
-      } else {
-        setText(command);
-      }
-    },
-    [abort, setActiveSessionKey, sendMessage],
-  );
-
-  // ─── Send ───
-  const handleSend = useCallback(() => {
-    if ((!text.trim() && attachments.length === 0) || streaming) return;
-    const payloads = toPayloads();
-    const uris = getImageUris();
-    sendMessage(text.trim(), payloads.length > 0 ? payloads : undefined, uris.length > 0 ? uris : undefined);
-    setText("");
-    clearAttachments();
-    setTimeout(() => flatListRef.current?.scrollToEnd({ animated: true }), 100);
-  }, [text, attachments, streaming, sendMessage, toPayloads, getImageUris, clearAttachments]);
-
-  // ─── Suggestion press (empty state) ───
-  const handleSuggestionPress = useCallback((prompt: string) => {
-    setText(prompt);
-  }, []);
-
-  const filteredMessages = useMemo(() =>
-    messages.filter((m) => m.content || m.streaming || m.toolCalls.length > 0),
-    [messages],
-  );
-
-  const renderItem = useCallback(({ item, index }: { item: DisplayMessage; index: number }) => {
-    const prev = index > 0 ? filteredMessages[index - 1] : undefined;
-    return <MessageBubble msg={item} previousMsg={prev} />;
-  }, [filteredMessages]);
-
-  const keyExtractor = useCallback((item: DisplayMessage) => item.id, []);
-
-  const dotColor = state === "connected" ? "#10B981" : state === "connecting" ? "#F59E0B" : state === "authenticating" ? "#3B82F6" : "#EF4444";
+  const dotColor =
+    state === "connected"
+      ? "#10B981"
+      : state === "connecting"
+        ? "#F59E0B"
+        : state === "authenticating"
+          ? "#3B82F6"
+          : "#EF4444";
   const isConnected = state === "connected";
 
-  return (
-    <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
-      {/* ─── AppBar (minimalist with menu) ─── */}
-      <AppBar
-        agentLabel={agentLabel}
-        sessionLabel={sessionLabel}
-        dotColor={dotColor}
-        isConnected={isConnected}
-        connectionState={state}
-        onSessionPress={() => { refreshSessions(); setSessionPickerOpen(true); }}
-        onSettingsPress={() => setSettingsOpen(true)}
-        onAgentSelect={() => setAgentSelectorOpen(true)}
-        onSkillPicker={() => setSkillPickerOpen(true)}
-      />
+  // ─── Tab / Page navigation ───
+  const goToPage = useCallback(
+    (index: number) => {
+      pagerRef.current?.setPage(index);
+      setActivePageIndex(index);
+    },
+    [],
+  );
 
-      <KeyboardAvoidingView
-        style={s.flex1}
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        keyboardVerticalOffset={8}
-      >
+  const handlePageSelected = useCallback(
+    (e: { nativeEvent: { position: number } }) => {
+      setActivePageIndex(e.nativeEvent.position);
+    },
+    [],
+  );
 
-        {/* Message area */}
-        {loading ? (
-          <View className="flex-1 items-center justify-center px-8">
-            <ActivityIndicator size="large" color="hsl(18 100% 56%)" />
-            <Text className="text-base font-medium text-muted-foreground mt-3">히스토리 로딩 중...</Text>
-          </View>
-        ) : filteredMessages.length === 0 ? (
-          <EmptyState
-            connected={isConnected}
-            onSuggestionPress={handleSuggestionPress}
-          />
-        ) : (
-          <View style={s.flex1}>
-            <FlatList
-              ref={flatListRef}
-              data={filteredMessages}
-              renderItem={renderItem}
-              keyExtractor={keyExtractor}
-              style={s.flex1}
-              contentContainerStyle={s.listContent}
-              onScroll={handleScroll}
-              scrollEventThrottle={100}
-              maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
-            />
-            <ScrollToBottomButton visible={userScrolledUp} onPress={scrollToBottom} />
-          </View>
-        )}
+  // ─── SessionSwitcher handler ───
+  const handleSessionSelect = useCallback(
+    (key: string | null) => {
+      if (!key) {
+        // "New / default" — clear override for the active agent
+        if (activeAgentId) {
+          setSessionKeyOverrides((prev) => {
+            const next = new Map(prev);
+            next.delete(activeAgentId);
+            return next;
+          });
+        }
+        return;
+      }
 
-        <AgentStatusBar status={agentStatus} />
+      const p = parseSessionKey(key);
+      const targetAgentId = p.agentId && p.agentId !== "unknown" ? p.agentId : activeAgentId;
 
-        {/* Agent indicator above input */}
-        {effectiveSessionKey && parsed?.agentId && (
-          <Pressable
-            className="flex-row items-center gap-2 px-5 py-3 bg-secondary border-t border-border active:opacity-70"
-            onPress={() => { refreshSessions(); setSessionPickerOpen(true); }}
-          >
-            <Bot size={16} color="hsl(18 100% 56%)" />
-            <Text className="text-base font-semibold text-primary">{parsed.agentId}</Text>
-            {parsed.type !== "main" && (
-              <Text className="text-sm text-muted-foreground">/ {parsed.detail || parsed.type}</Text>
-            )}
-            <ChevronDown size={14} color="hsl(0 0% 45%)" />
-          </Pressable>
-        )}
+      if (targetAgentId) {
+        // Override sessionKey for that agent
+        setSessionKeyOverrides((prev) => {
+          const next = new Map(prev);
+          next.set(targetAgentId, key);
+          return next;
+        });
 
-        {/* Attachment preview */}
-        <AttachmentPreview attachments={attachments} onRemove={removeAttachment} />
+        // If the selected session belongs to a different agent, navigate to its page
+        const targetIndex = agents.findIndex((a) => a.id === targetAgentId);
+        if (targetIndex >= 0 && targetIndex !== activePageIndex) {
+          goToPage(targetIndex);
+        }
+      }
+    },
+    [activeAgentId, agents, activePageIndex, goToPage],
+  );
 
-        {/* Slash command suggestions */}
-        {showSlashPicker && (
-          <SlashCommands
-            inputText={text}
-            onSelect={handleSlashSelect}
-            onDismiss={() => setText("")}
-          />
-        )}
+  // ─── Fallback: no agents ───
+  if (agentsLoading) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center" style={{ paddingTop: insets.top }}>
+        <ActivityIndicator size="large" color="hsl(18 100% 56%)" />
+        <Text className="text-base font-medium text-muted-foreground mt-3">에이전트 로딩 중...</Text>
+      </View>
+    );
+  }
 
-        {/* Input bar (redesigned) */}
-        <InputBar
-          text={text}
-          onChangeText={setText}
-          onSend={handleSend}
-          onAbort={abort}
-          onAttach={addAttachments}
-          streaming={streaming}
-          connected={isConnected}
-          hasContent={!!(text.trim() || attachments.length > 0)}
-          bottomInset={insets.bottom}
-          keyboardVisible={keyboardVisible}
+  if (agents.length === 0) {
+    return (
+      <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
+        <AppBar
+          agentLabel="Chat"
+          sessionLabel=""
+          dotColor={dotColor}
+          isConnected={isConnected}
+          connectionState={state}
+          onSessionPress={() => {}}
+          onSettingsPress={() => setSettingsOpen(true)}
+          onAgentSelect={() => setAgentSelectorOpen(true)}
+          onSkillPicker={() => setSkillPickerOpen(true)}
         />
+        <View className="flex-1 items-center justify-center px-8">
+          <Bot size={48} color="hsl(0 0% 45%)" strokeWidth={1.5} />
+          <Text className="text-lg font-semibold text-foreground mt-4">에이전트 없음</Text>
+          <Text className="text-base text-muted-foreground text-center mt-2">
+            {isConnected
+              ? "등록된 에이전트가 없습니다. Gateway 설정을 확인하세요."
+              : "Gateway에 연결되지 않았습니다."}
+          </Text>
+        </View>
 
-        {/* Session switcher */}
-        <SessionSwitcher
-          visible={sessionPickerOpen}
-          onClose={() => setSessionPickerOpen(false)}
-          sessions={sessions}
-          sessionsLoading={sessionsLoading}
-          onRefresh={refreshSessions}
-          currentKey={effectiveSessionKey}
-          mainSessionKey={mainSessionKey}
-          onSelect={(key) => {
-            if (key === mainSessionKey) {
-              setActiveSessionKey(null);
-            } else {
-              setActiveSessionKey(key);
-            }
-            // Sync agent selection from the chosen session
-            const p = parseSessionKey(key);
-            if (p.agentId && p.agentId !== "unknown") {
-              setSelectedAgentId(p.agentId);
-            }
-          }}
-        />
-
-        {/* Agent selector */}
+        {/* Agent selector — fallback for when agents appear later */}
         <AgentSelector
           visible={agentSelectorOpen}
           onClose={() => setAgentSelectorOpen(false)}
-          selectedId={selectedAgentId}
-          onSelect={(id) => {
-            setSelectedAgentId(id);
-            // Clear explicit session so effectiveSessionKey switches to agent:{id}:main
-            setActiveSessionKey(null);
-          }}
+          onSelect={() => {}}
         />
 
         {/* Skill picker */}
@@ -291,7 +178,99 @@ export default function ChatScreen() {
           visible={skillPickerOpen}
           onClose={() => setSkillPickerOpen(false)}
         />
-      </KeyboardAvoidingView>
+
+        {/* Settings modal */}
+        <Modal visible={settingsOpen} animationType="slide" onRequestClose={() => setSettingsOpen(false)}>
+          <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
+            <View className="flex-row items-center justify-between h-14 px-5 border-b border-border">
+              <Text className="text-lg font-bold text-foreground">Settings</Text>
+              <Pressable onPress={() => setSettingsOpen(false)} hitSlop={8}>
+                <Text className="text-base font-semibold text-primary">닫기</Text>
+              </Pressable>
+            </View>
+            <SettingsScreen />
+          </View>
+        </Modal>
+      </View>
+    );
+  }
+
+  // ─── Main render: PagerView with agents ───
+  return (
+    <View style={s.flex1} className="bg-background" >
+      <View style={{ paddingTop: insets.top }}>
+        {/* AppBar */}
+        <AppBar
+          agentLabel={agentLabel}
+          sessionLabel={sessionLabel}
+          dotColor={dotColor}
+          isConnected={isConnected}
+          connectionState={state}
+          onSessionPress={() => { refreshSessions(); setSessionPickerOpen(true); }}
+          onSettingsPress={() => setSettingsOpen(true)}
+          onAgentSelect={() => setAgentSelectorOpen(true)}
+          onSkillPicker={() => setSkillPickerOpen(true)}
+        />
+
+        {/* Agent tab bar (hidden when only 1 agent) */}
+        <AgentTabBar
+          agents={agents}
+          activeIndex={activePageIndex}
+          onTabPress={goToPage}
+        />
+      </View>
+
+      {/* PagerView — native swipe between agent chats */}
+      <PagerView
+        ref={pagerRef}
+        style={s.flex1}
+        initialPage={0}
+        onPageSelected={handlePageSelected}
+      >
+        {agents.map((agent, index) => (
+          <View key={agent.id} style={s.flex1}>
+            <AgentChatPage
+              sessionKey={getSessionKeyForAgent(agent.id)}
+              agentId={agent.id}
+              isActive={index === activePageIndex}
+            />
+          </View>
+        ))}
+      </PagerView>
+
+      {/* ─── Modals ─── */}
+
+      {/* Session switcher */}
+      <SessionSwitcher
+        visible={sessionPickerOpen}
+        onClose={() => setSessionPickerOpen(false)}
+        sessions={sessions}
+        sessionsLoading={sessionsLoading}
+        onRefresh={refreshSessions}
+        currentKey={effectiveSessionKey}
+        mainSessionKey={mainSessionKey}
+        onSelect={handleSessionSelect}
+      />
+
+      {/* Agent selector — long press / menu fallback */}
+      <AgentSelector
+        visible={agentSelectorOpen}
+        onClose={() => setAgentSelectorOpen(false)}
+        selectedId={activeAgentId}
+        onSelect={(id) => {
+          if (!id) return;
+          const idx = agents.findIndex((a) => a.id === id);
+          if (idx >= 0) {
+            goToPage(idx);
+          }
+        }}
+      />
+
+      {/* Skill picker */}
+      <SkillPicker
+        visible={skillPickerOpen}
+        onClose={() => setSkillPickerOpen(false)}
+      />
 
       {/* Settings modal */}
       <Modal visible={settingsOpen} animationType="slide" onRequestClose={() => setSettingsOpen(false)}>
@@ -313,8 +292,4 @@ export default function ChatScreen() {
 
 const s = StyleSheet.create({
   flex1: { flex: 1 },
-  listContent: {
-    paddingVertical: 10,
-    paddingHorizontal: 2,
-  },
 });

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -18,6 +18,7 @@ import { ExpoCryptoAdapter } from "../src/adapters/crypto";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { mmkvStorage } from "../src/adapters/storage";
 import { SessionContext } from "../src/stores/sessionStore";
+import { ChatStateProvider } from "../src/stores/ChatStateProvider";
 
 // Initialize crypto adapter (must be called once before gateway connects)
 initCryptoAdapter(new ExpoCryptoAdapter());
@@ -84,8 +85,10 @@ export default function RootLayout() {
             token={config.token}
             onConfigChange={saveConfig}
           >
-            <StatusBar style="auto" />
-            <Slot />
+            <ChatStateProvider>
+              <StatusBar style="auto" />
+              <Slot />
+            </ChatStateProvider>
           </GatewayProvider>
         </SessionContext.Provider>
       </SafeAreaProvider>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -43,6 +43,7 @@
     "react-native-get-random-values": "^1.11.0",
     "react-native-markdown-display": "^7.0.2",
     "react-native-mmkv": "^3.2.0",
+    "react-native-pager-view": "^8.0.0",
     "react-native-reanimated": "~4.1.6",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.16.0",

--- a/apps/mobile/src/components/chat/AgentChatPage.tsx
+++ b/apps/mobile/src/components/chat/AgentChatPage.tsx
@@ -1,0 +1,201 @@
+import React, { useState, useRef, useCallback, useEffect, useMemo } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+  StyleSheet,
+  Keyboard,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useGateway } from "@intelli-claw/shared";
+import { useChat, type DisplayMessage } from "../../hooks/useChat";
+import { AttachmentPreview, useFileAttachments } from "../FileAttachments";
+import { SlashCommands, shouldShowSlashPicker } from "../SlashCommands";
+import {
+  MessageBubble,
+  EmptyState,
+  AgentStatusBar,
+  InputBar,
+  ScrollToBottomButton,
+} from "./index";
+
+// ─── Props ───
+
+export interface AgentChatPageProps {
+  sessionKey: string | undefined;
+  agentId: string | undefined;
+  /** Whether this page is currently visible (scroll/keyboard optimization) */
+  isActive: boolean;
+}
+
+// ─── AgentChatPage ───
+
+export function AgentChatPage({ sessionKey, agentId, isActive }: AgentChatPageProps) {
+  const insets = useSafeAreaInsets();
+  const { state } = useGateway();
+
+  const { messages, streaming, loading, agentStatus, sendMessage, abort } = useChat(sessionKey);
+
+  const [text, setText] = useState("");
+  const { attachments, addAttachments, removeAttachment, clearAttachments, toPayloads, imageUris: getImageUris } = useFileAttachments();
+  const showSlashPicker = shouldShowSlashPicker(text);
+  const flatListRef = useRef<FlatList>(null);
+  const [userScrolledUp, setUserScrolledUp] = useState(false);
+  const isAtBottomRef = useRef(true);
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
+
+  const isConnected = state === "connected";
+
+  // ─── Keyboard tracking ───
+  useEffect(() => {
+    if (!isActive) return;
+    const showSub = Keyboard.addListener("keyboardWillShow", () => setKeyboardVisible(true));
+    const hideSub = Keyboard.addListener("keyboardWillHide", () => setKeyboardVisible(false));
+    return () => { showSub.remove(); hideSub.remove(); };
+  }, [isActive]);
+
+  // ─── Smart auto-scroll ───
+  const handleScroll = useCallback((e: any) => {
+    const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
+    const atBottom = contentOffset.y + layoutMeasurement.height >= contentSize.height - 80;
+    isAtBottomRef.current = atBottom;
+    setUserScrolledUp(!atBottom);
+  }, []);
+
+  useEffect(() => {
+    if (isAtBottomRef.current && flatListRef.current) {
+      flatListRef.current.scrollToEnd({ animated: true });
+    }
+  }, [messages.length, streaming]);
+
+  const scrollToBottom = useCallback(() => {
+    flatListRef.current?.scrollToEnd({ animated: true });
+    setUserScrolledUp(false);
+    isAtBottomRef.current = true;
+  }, []);
+
+  // ─── Slash command handler ───
+  const handleSlashSelect = useCallback(
+    (command: string, immediate?: boolean) => {
+      if (immediate) {
+        if (command === "/stop") {
+          abort();
+        } else if (command === "/reset") {
+          sendMessage(command);
+        } else {
+          sendMessage(command);
+        }
+        setText("");
+      } else {
+        setText(command);
+      }
+    },
+    [abort, sendMessage],
+  );
+
+  // ─── Send ───
+  const handleSend = useCallback(() => {
+    if ((!text.trim() && attachments.length === 0) || streaming) return;
+    const payloads = toPayloads();
+    const uris = getImageUris();
+    sendMessage(text.trim(), payloads.length > 0 ? payloads : undefined, uris.length > 0 ? uris : undefined);
+    setText("");
+    clearAttachments();
+    setTimeout(() => flatListRef.current?.scrollToEnd({ animated: true }), 100);
+  }, [text, attachments, streaming, sendMessage, toPayloads, getImageUris, clearAttachments]);
+
+  // ─── Suggestion press (empty state) ───
+  const handleSuggestionPress = useCallback((prompt: string) => {
+    setText(prompt);
+  }, []);
+
+  const filteredMessages = useMemo(() =>
+    messages.filter((m) => m.content || m.streaming || m.toolCalls.length > 0),
+    [messages],
+  );
+
+  const renderItem = useCallback(({ item, index }: { item: DisplayMessage; index: number }) => {
+    const prev = index > 0 ? filteredMessages[index - 1] : undefined;
+    return <MessageBubble msg={item} previousMsg={prev} />;
+  }, [filteredMessages]);
+
+  const keyExtractor = useCallback((item: DisplayMessage) => item.id, []);
+
+  return (
+    <KeyboardAvoidingView
+      style={s.flex1}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      keyboardVerticalOffset={8}
+    >
+
+      {/* Message area */}
+      {loading ? (
+        <View className="flex-1 items-center justify-center px-8">
+          <ActivityIndicator size="large" color="hsl(18 100% 56%)" />
+          <Text className="text-base font-medium text-muted-foreground mt-3">히스토리 로딩 중...</Text>
+        </View>
+      ) : filteredMessages.length === 0 ? (
+        <EmptyState
+          connected={isConnected}
+          onSuggestionPress={handleSuggestionPress}
+        />
+      ) : (
+        <View style={s.flex1}>
+          <FlatList
+            ref={flatListRef}
+            data={filteredMessages}
+            renderItem={renderItem}
+            keyExtractor={keyExtractor}
+            style={s.flex1}
+            contentContainerStyle={s.listContent}
+            onScroll={handleScroll}
+            scrollEventThrottle={100}
+            maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
+          />
+          <ScrollToBottomButton visible={userScrolledUp} onPress={scrollToBottom} />
+        </View>
+      )}
+
+      <AgentStatusBar status={agentStatus} />
+
+      {/* Attachment preview */}
+      <AttachmentPreview attachments={attachments} onRemove={removeAttachment} />
+
+      {/* Slash command suggestions */}
+      {showSlashPicker && (
+        <SlashCommands
+          inputText={text}
+          onSelect={handleSlashSelect}
+          onDismiss={() => setText("")}
+        />
+      )}
+
+      {/* Input bar */}
+      <InputBar
+        text={text}
+        onChangeText={setText}
+        onSend={handleSend}
+        onAbort={abort}
+        onAttach={addAttachments}
+        streaming={streaming}
+        connected={isConnected}
+        hasContent={!!(text.trim() || attachments.length > 0)}
+        bottomInset={insets.bottom}
+        keyboardVisible={keyboardVisible}
+      />
+    </KeyboardAvoidingView>
+  );
+}
+
+// ─── Styles ───
+
+const s = StyleSheet.create({
+  flex1: { flex: 1 },
+  listContent: {
+    paddingVertical: 10,
+    paddingHorizontal: 2,
+  },
+});

--- a/apps/mobile/src/components/chat/AgentTabBar.tsx
+++ b/apps/mobile/src/components/chat/AgentTabBar.tsx
@@ -1,0 +1,240 @@
+/**
+ * AgentTabBar — Horizontal tab bar for switching between agent chats.
+ *
+ * Features:
+ * - Animated underline indicator (react-native-reanimated)
+ * - Streaming agent pulse indicator
+ * - Unread message count badge
+ * - Horizontal scroll for many agents
+ */
+import React, { useCallback, useEffect, useRef } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  ScrollView,
+  type LayoutChangeEvent,
+} from "react-native";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  withRepeat,
+  withSequence,
+  Easing,
+} from "react-native-reanimated";
+import { cn } from "@/lib/utils";
+
+/* ─── Palette (synced with AgentSelector) ─── */
+
+const PALETTE = [
+  "#6366F1", "#EC4899", "#F59E0B", "#10B981", "#8B5CF6",
+  "#14B8A6", "#F97316", "#EF4444", "#06B6D4", "#3B82F6",
+];
+
+function getAgentColor(agentId: string): string {
+  let hash = 0;
+  for (let i = 0; i < agentId.length; i++) {
+    hash = ((hash << 5) - hash + agentId.charCodeAt(i)) | 0;
+  }
+  return PALETTE[Math.abs(hash) % PALETTE.length];
+}
+
+/* ─── Types ─── */
+
+export interface AgentTabBarProps {
+  agents: Array<{ id: string; name?: string }>;
+  activeIndex: number;
+  onTabPress: (index: number) => void;
+  streamingAgentIds?: Set<string>;
+  unreadCounts?: Map<string, number>;
+}
+
+/* ─── Constants ─── */
+
+const TAB_HEIGHT = 44;
+const INDICATOR_HEIGHT = 3;
+const INDICATOR_RADIUS = 1.5;
+
+/* ─── Component ─── */
+
+export function AgentTabBar({
+  agents,
+  activeIndex,
+  onTabPress,
+  streamingAgentIds,
+  unreadCounts,
+}: AgentTabBarProps) {
+  const scrollRef = useRef<ScrollView>(null);
+
+  // Track tab layouts for indicator positioning
+  const tabLayouts = useRef<Array<{ x: number; width: number }>>([]);
+
+  // Animated values for the underline indicator
+  const indicatorX = useSharedValue(0);
+  const indicatorW = useSharedValue(0);
+
+  // Active agent color (for indicator)
+  const activeColor = agents[activeIndex]
+    ? getAgentColor(agents[activeIndex].id)
+    : PALETTE[0];
+
+  // Update indicator position when activeIndex changes
+  useEffect(() => {
+    const layout = tabLayouts.current[activeIndex];
+    if (layout) {
+      indicatorX.value = withTiming(layout.x, {
+        duration: 250,
+        easing: Easing.out(Easing.cubic),
+      });
+      indicatorW.value = withTiming(layout.width, {
+        duration: 250,
+        easing: Easing.out(Easing.cubic),
+      });
+    }
+  }, [activeIndex, indicatorX, indicatorW]);
+
+  // Scroll active tab into view
+  useEffect(() => {
+    const layout = tabLayouts.current[activeIndex];
+    if (layout && scrollRef.current) {
+      scrollRef.current.scrollTo({
+        x: Math.max(0, layout.x - 40),
+        animated: true,
+      });
+    }
+  }, [activeIndex]);
+
+  const handleTabLayout = useCallback(
+    (index: number, event: LayoutChangeEvent) => {
+      const { x, width } = event.nativeEvent.layout;
+      tabLayouts.current[index] = { x, width };
+
+      // Set initial position without animation for the active tab
+      if (index === activeIndex) {
+        indicatorX.value = x;
+        indicatorW.value = width;
+      }
+    },
+    [activeIndex, indicatorX, indicatorW],
+  );
+
+  const indicatorStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: indicatorX.value }],
+    width: indicatorW.value,
+  }));
+
+  if (agents.length <= 1) return null;
+
+  return (
+    <View
+      className="bg-background border-b border-border"
+      style={{ height: TAB_HEIGHT }}
+    >
+      <ScrollView
+        ref={scrollRef}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerClassName="flex-row items-stretch"
+      >
+        {agents.map((agent, index) => {
+          const isActive = index === activeIndex;
+          const color = getAgentColor(agent.id);
+          const isStreaming = streamingAgentIds?.has(agent.id) ?? false;
+          const unread = unreadCounts?.get(agent.id) ?? 0;
+
+          return (
+            <Pressable
+              key={agent.id}
+              className={cn(
+                "flex-row items-center justify-center px-4 gap-1.5",
+                isActive ? "opacity-100" : "opacity-60",
+              )}
+              style={{ height: TAB_HEIGHT }}
+              onLayout={(e) => handleTabLayout(index, e)}
+              onPress={() => onTabPress(index)}
+              accessibilityLabel={`${agent.name || agent.id} 에이전트`}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: isActive }}
+            >
+              {/* Streaming pulse dot */}
+              {isStreaming && <StreamingDot color={color} />}
+
+              <Text
+                className={cn(
+                  "text-sm font-semibold",
+                  isActive ? "text-foreground" : "text-muted-foreground",
+                )}
+                numberOfLines={1}
+                style={isActive ? { color } : undefined}
+              >
+                {agent.name || agent.id}
+              </Text>
+
+              {/* Unread badge */}
+              {unread > 0 && !isActive && (
+                <View
+                  className="min-w-[18px] h-[18px] rounded-full items-center justify-center px-1"
+                  style={{ backgroundColor: color }}
+                >
+                  <Text className="text-[11px] font-bold text-white">
+                    {unread > 99 ? "99+" : unread}
+                  </Text>
+                </View>
+              )}
+            </Pressable>
+          );
+        })}
+
+        {/* Animated underline indicator */}
+        <Animated.View
+          style={[
+            {
+              position: "absolute",
+              bottom: 0,
+              height: INDICATOR_HEIGHT,
+              borderRadius: INDICATOR_RADIUS,
+              backgroundColor: activeColor,
+            },
+            indicatorStyle,
+          ]}
+        />
+      </ScrollView>
+    </View>
+  );
+}
+
+/* ─── StreamingDot ─── */
+
+function StreamingDot({ color }: { color: string }) {
+  const opacity = useSharedValue(1);
+
+  useEffect(() => {
+    opacity.value = withRepeat(
+      withSequence(
+        withTiming(0.2, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+        withTiming(1, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+      ),
+      -1, // infinite
+      false,
+    );
+  }, [opacity]);
+
+  const dotStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        {
+          width: 6,
+          height: 6,
+          borderRadius: 3,
+          backgroundColor: color,
+        },
+        dotStyle,
+      ]}
+    />
+  );
+}

--- a/apps/mobile/src/components/chat/index.ts
+++ b/apps/mobile/src/components/chat/index.ts
@@ -6,3 +6,5 @@ export { AgentStatusBar } from "./AgentStatusBar";
 export { InputBar } from "./InputBar";
 export { ScrollToBottomButton } from "./ScrollToBottom";
 export { AppBar } from "./AppBar";
+export { AgentChatPage } from "./AgentChatPage";
+export type { AgentChatPageProps } from "./AgentChatPage";

--- a/apps/mobile/src/hooks/useChat.ts
+++ b/apps/mobile/src/hooks/useChat.ts
@@ -1,309 +1,43 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import {
-  useGateway,
-  type EventFrame,
-  type ChatMessage,
-  type ToolCall,
-} from "@intelli-claw/shared";
+import { useCallback } from "react";
+import { useGateway } from "@intelli-claw/shared";
+import { useChatState } from "./useChatState";
+import { useChatStateManager } from "../stores/ChatStateProvider";
 
-// ─── Types ───
-
-export interface DisplayMessage {
-  id: string;
-  role: "user" | "assistant" | "system";
-  content: string;
-  timestamp: string;
-  toolCalls: ToolCall[];
-  streaming?: boolean;
-  /** Local image URIs for user-sent attachments (display only) */
-  imageUris?: string[];
-}
-
-export type AgentStatus =
-  | { phase: "idle" }
-  | { phase: "thinking" }
-  | { phase: "writing" }
-  | { phase: "tool"; toolName: string };
-
-/** Messages matching this pattern are housekeeping noise — hide from the user. */
-const HIDDEN_RE = /^(NO_REPLY|HEARTBEAT_OK|NO_)\s*$|^System:|^\[System|Pre-compaction memory flush|^Read HEARTBEAT\.md|reply with NO_REPLY|Store durable memories now/;
+// ─── Re-export types for backward compatibility ───
+export type { DisplayMessage, AgentStatus } from "../stores/chatStateManager";
 
 // ─── Hook ───
 
 export function useChat(sessionKey?: string) {
+  const { messages, streaming, loading, agentStatus } =
+    useChatState(sessionKey);
   const { client, state } = useGateway();
-  const [messages, setMessages] = useState<DisplayMessage[]>([]);
-  const [streaming, setStreaming] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [agentStatus, setAgentStatus] = useState<AgentStatus>({ phase: "idle" });
-
-  const streamBuf = useRef<{
-    id: string;
-    content: string;
-    toolCalls: Map<string, ToolCall>;
-  } | null>(null);
-  const runIdRef = useRef<string | null>(null);
-  const sessionKeyRef = useRef(sessionKey);
-  const streamingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const STREAMING_TIMEOUT_MS = 45_000;
-
-  const clearStreamingTimeout = useCallback(() => {
-    if (streamingTimeoutRef.current) {
-      clearTimeout(streamingTimeoutRef.current);
-      streamingTimeoutRef.current = null;
-    }
-  }, []);
-
-  const startStreamingTimeout = useCallback(() => {
-    clearStreamingTimeout();
-    streamingTimeoutRef.current = setTimeout(() => {
-      console.warn("[useChat] streaming timeout — forcing idle");
-      setStreaming(false);
-      setAgentStatus({ phase: "idle" });
-      if (streamBuf.current) {
-        const finalId = streamBuf.current.id;
-        setMessages((prev) =>
-          prev.map((m) => m.id === finalId ? { ...m, streaming: false } : m),
-        );
-        streamBuf.current = null;
-      }
-    }, STREAMING_TIMEOUT_MS);
-  }, [clearStreamingTimeout]);
-
-  // ─── Reset on session change ───
-  useEffect(() => {
-    if (sessionKeyRef.current !== sessionKey) {
-      sessionKeyRef.current = sessionKey;
-      setMessages([]);
-      setStreaming(false);
-      clearStreamingTimeout();
-      setAgentStatus({ phase: "idle" });
-      streamBuf.current = null;
-      runIdRef.current = null;
-    }
-  }, [sessionKey, clearStreamingTimeout]);
-
-  // ─── Load history ───
-  const loadHistory = useCallback(async () => {
-    if (!client || state !== "connected" || !sessionKey) return;
-    setLoading(true);
-    try {
-      const res = await client.request<{ messages: ChatMessage[] }>(
-        "chat.history",
-        { sessionKey, limit: 100 },
-      );
-      const histMsgs: DisplayMessage[] = (res?.messages || [])
-        .filter((m) => {
-          if (m.role !== "user" && m.role !== "assistant") return false;
-          const blocks = m.content as any;
-          const raw = typeof m.content === "string" ? m.content
-            : Array.isArray(blocks) ? blocks.map((b: any) => b?.text || "").join("") : String(m.content || "");
-          return !HIDDEN_RE.test(raw.trim());
-        })
-        .map((m, i) => {
-          const blocks = m.content as any;
-          let text = typeof m.content === "string" ? m.content
-            : Array.isArray(blocks) ? blocks.map((b: any) => b?.text || "").join("") : String(m.content || "");
-          text = text.replace(/\n{3,}/g, "\n\n").trim();
-          return {
-            id: `hist-${i}`,
-            role: m.role as "user" | "assistant",
-            content: text,
-            timestamp: m.timestamp || new Date().toISOString(),
-            toolCalls: m.toolCalls || [],
-          };
-        });
-      setMessages(histMsgs);
-    } catch (err) {
-      console.error("[useChat] history error:", err);
-    } finally {
-      setLoading(false);
-    }
-  }, [client, state, sessionKey]);
-
-  useEffect(() => {
-    loadHistory();
-  }, [loadHistory]);
-
-  // ─── Stream handler (mirrors web/electron pattern) ───
-  useEffect(() => {
-    if (!client) return;
-
-    const unsub = client.onEvent((frame: EventFrame) => {
-      if (frame.event !== "agent") return;
-      const raw = frame.payload as Record<string, unknown>;
-      const stream = raw.stream as string | undefined;
-      const data = raw.data as Record<string, unknown> | undefined;
-      // Check both top-level sessionKey and data.sessionKey — gateway may
-      // nest the key inside data depending on event type (#48)
-      const evtSessionKey = (raw.sessionKey ?? data?.sessionKey) as string | undefined;
-
-      // Only process events for our session (use ref to avoid stale closure)
-      const currentKey = sessionKeyRef.current;
-      if (currentKey && evtSessionKey && evtSessionKey !== currentKey) return;
-      if (!evtSessionKey && currentKey) return;
-
-      // ── assistant text delta ──
-      if (stream === "assistant" && (typeof data?.delta === "string" || typeof data?.text === "string")) {
-        const chunk = (data?.delta as string | undefined) ?? (data?.text as string);
-        setStreaming(true);
-        startStreamingTimeout();
-        setAgentStatus({ phase: "writing" });
-
-        if (!streamBuf.current) {
-          streamBuf.current = { id: `stream-${Date.now()}`, content: "", toolCalls: new Map() };
-        }
-        streamBuf.current.content += chunk;
-        const snap = streamBuf.current;
-
-        setMessages((prev) => {
-          const idx = prev.findIndex((m) => m.id === snap.id);
-          const msg: DisplayMessage = {
-            id: snap.id, role: "assistant", content: snap.content,
-            timestamp: new Date().toISOString(),
-            toolCalls: Array.from(snap.toolCalls.values()), streaming: true,
-          };
-          if (idx >= 0) { const next = [...prev]; next[idx] = msg; return next; }
-          return [...prev, msg];
-        });
-
-      // ── tool start ──
-      } else if (stream === "tool-start" && data) {
-        const callId = String(data.toolCallId || data.callId || "");
-        const name = String(data.name || data.tool || "");
-        setAgentStatus({ phase: "tool", toolName: name });
-
-        if (!streamBuf.current) {
-          streamBuf.current = { id: `stream-${Date.now()}`, content: "", toolCalls: new Map() };
-        }
-        streamBuf.current.toolCalls.set(callId, { callId, name, status: "running" });
-        const snap = streamBuf.current;
-
-        setMessages((prev) => {
-          const idx = prev.findIndex((m) => m.id === snap.id);
-          const msg: DisplayMessage = {
-            id: snap.id, role: "assistant", content: snap.content,
-            timestamp: new Date().toISOString(),
-            toolCalls: Array.from(snap.toolCalls.values()), streaming: true,
-          };
-          if (idx >= 0) { const next = [...prev]; next[idx] = msg; return next; }
-          return [...prev, msg];
-        });
-
-      // ── tool end ──
-      } else if (stream === "tool-end" && data) {
-        const callId = String(data.toolCallId || data.callId || "");
-        const result = data.result as string | undefined;
-        setAgentStatus({ phase: "thinking" });
-
-        if (streamBuf.current) {
-          const tc = streamBuf.current.toolCalls.get(callId);
-          if (tc) { tc.status = "done"; tc.result = result; }
-          const snap = streamBuf.current;
-          setMessages((prev) => {
-            const idx = prev.findIndex((m) => m.id === snap.id);
-            if (idx >= 0) {
-              const next = [...prev];
-              next[idx] = { ...next[idx], toolCalls: Array.from(snap.toolCalls.values()) };
-              return next;
-            }
-            return prev;
-          });
-        }
-
-      // ── lifecycle start ──
-      } else if (stream === "lifecycle" && data?.phase === "start") {
-        setStreaming(true);
-        startStreamingTimeout();
-        runIdRef.current = (raw.runId as string) ?? null;
-        setAgentStatus({ phase: "thinking" });
-
-      // ── lifecycle end ──
-      } else if (stream === "lifecycle" && data?.phase === "end") {
-        clearStreamingTimeout();
-        setStreaming(false);
-        setAgentStatus({ phase: "idle" });
-
-        if (streamBuf.current) {
-          const finalId = streamBuf.current.id;
-          const finalContent = streamBuf.current.content;
-          const finalTools = Array.from(streamBuf.current.toolCalls.values());
-          if (HIDDEN_RE.test(finalContent.trim())) {
-            setMessages((prev) => prev.filter((m) => m.id !== finalId));
-          } else {
-            setMessages((prev) =>
-              prev.map((m) => m.id === finalId
-                ? { ...m, content: finalContent, toolCalls: finalTools, streaming: false }
-                : m),
-            );
-          }
-          streamBuf.current = null;
-        }
-
-      // ── done/end/finish (alternative end signals) ──
-      } else if (stream === "done" || stream === "end" || stream === "finish") {
-        clearStreamingTimeout();
-        setStreaming(false);
-        setAgentStatus({ phase: "idle" });
-
-        if (streamBuf.current) {
-          const finalId = streamBuf.current.id;
-          const finalContent = (data?.text as string) || streamBuf.current.content;
-          const finalTools = Array.from(streamBuf.current.toolCalls.values());
-          if (HIDDEN_RE.test(finalContent.trim())) {
-            setMessages((prev) => prev.filter((m) => m.id !== finalId));
-            streamBuf.current = null;
-            return;
-          }
-          setMessages((prev) =>
-            prev.map((m) => m.id === finalId
-              ? { ...m, content: finalContent, toolCalls: finalTools, streaming: false }
-              : m),
-          );
-          streamBuf.current = null;
-        }
-
-      // ── error ──
-      } else if (stream === "error") {
-        clearStreamingTimeout();
-        setStreaming(false);
-        setAgentStatus({ phase: "idle" });
-        const errMsg = String(data?.message || data?.error || "Unknown error");
-
-        if (streamBuf.current) {
-          const errId = streamBuf.current.id;
-          setMessages((prev) =>
-            prev.map((m) => m.id === errId
-              ? { ...m, content: m.content + `\n\n**Error:** ${errMsg}`, streaming: false }
-              : m),
-          );
-          streamBuf.current = null;
-        }
-      }
-    });
-
-    return () => {
-      unsub();
-      clearStreamingTimeout();
-    };
-  }, [client, startStreamingTimeout, clearStreamingTimeout]);
+  const manager = useChatStateManager();
 
   // ─── Send message ───
   const sendMessage = useCallback(
-    async (text: string, attachments?: Array<{ content: string; data?: string; mimeType: string; fileName?: string }>, imageUris?: string[]) => {
+    async (
+      text: string,
+      attachments?: Array<{
+        content: string;
+        data?: string;
+        mimeType: string;
+        fileName?: string;
+      }>,
+      imageUris?: string[],
+    ) => {
       if (!client || state !== "connected" || !sessionKey) return;
       if (!text.trim() && (!attachments || attachments.length === 0)) return;
 
-      const userMsg: DisplayMessage = {
+      // Optimistic user message
+      manager.appendUserMessage(sessionKey, {
         id: `user-${Date.now()}`,
         role: "user",
         content: text.trim() || (attachments?.length ? "(이미지)" : ""),
         timestamp: new Date().toISOString(),
         toolCalls: [],
         imageUris: imageUris?.length ? imageUris : undefined,
-      };
-      setMessages((prev) => [...prev, userMsg]);
+      });
 
       try {
         const payload: Record<string, unknown> = {
@@ -323,16 +57,19 @@ export function useChat(sessionKey?: string) {
         console.error("[useChat] send error:", err);
       }
     },
-    [client, state, sessionKey],
+    [client, state, sessionKey, manager],
   );
 
   // ─── Abort ───
   const abort = useCallback(async () => {
     if (!client || !sessionKey) return;
     try {
-      await client.request("chat.abort", { sessionKey, runId: runIdRef.current });
-    } catch {}
-  }, [client, sessionKey]);
+      const runId = manager.getRunId(sessionKey);
+      await client.request("chat.abort", { sessionKey, runId });
+    } catch {
+      // swallow abort errors
+    }
+  }, [client, sessionKey, manager]);
 
   return {
     messages,
@@ -341,6 +78,5 @@ export function useChat(sessionKey?: string) {
     agentStatus,
     sendMessage,
     abort,
-    reload: loadHistory,
   };
 }

--- a/apps/mobile/src/hooks/useChatState.ts
+++ b/apps/mobile/src/hooks/useChatState.ts
@@ -1,0 +1,41 @@
+/**
+ * Thin subscription hook — connects a React component to a single session
+ * inside the central ChatStateManager via useSyncExternalStore.
+ */
+import { useEffect, useSyncExternalStore } from "react";
+import { useGateway } from "@intelli-claw/shared";
+import { useChatStateManager } from "../stores/ChatStateProvider";
+import type { ChatState } from "../stores/chatStateManager";
+
+const DEFAULT_STATE: ChatState = {
+  messages: [],
+  streaming: false,
+  agentStatus: { phase: "idle" },
+  loading: false,
+  streamBuf: null,
+  runId: null,
+  historyLoaded: false,
+  lastAccessedAt: 0,
+};
+
+const NOOP = () => () => {};
+
+export function useChatState(sessionKey?: string): ChatState {
+  const manager = useChatStateManager();
+  const { client, state: gwState } = useGateway();
+
+  const chatState = useSyncExternalStore(
+    (onStoreChange) =>
+      sessionKey ? manager.subscribe(sessionKey, onStoreChange) : NOOP(),
+    () => (sessionKey ? manager.getState(sessionKey) : DEFAULT_STATE),
+  );
+
+  // Lazy history load — runs once per session when connected
+  useEffect(() => {
+    if (sessionKey && client && gwState === "connected") {
+      manager.loadHistory(client, sessionKey);
+    }
+  }, [sessionKey, client, gwState, manager]);
+
+  return chatState;
+}

--- a/apps/mobile/src/stores/ChatStateProvider.tsx
+++ b/apps/mobile/src/stores/ChatStateProvider.tsx
@@ -1,0 +1,35 @@
+/**
+ * React context that owns the singleton ChatStateManager and binds it
+ * to the current GatewayClient connection.
+ */
+import React, { createContext, useContext, useEffect, useRef } from "react";
+import { useGateway } from "@intelli-claw/shared";
+import { ChatStateManager } from "./chatStateManager";
+
+const ChatStateContext = createContext<ChatStateManager>(null!);
+
+export function ChatStateProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const manager = useRef(new ChatStateManager()).current;
+  const { client, state } = useGateway();
+
+  useEffect(() => {
+    if (client && state === "connected") {
+      manager.bind(client);
+      return () => manager.unbind();
+    }
+  }, [client, state, manager]);
+
+  return (
+    <ChatStateContext.Provider value={manager}>
+      {children}
+    </ChatStateContext.Provider>
+  );
+}
+
+export function useChatStateManager(): ChatStateManager {
+  return useContext(ChatStateContext);
+}

--- a/apps/mobile/src/stores/chatStateManager.ts
+++ b/apps/mobile/src/stores/chatStateManager.ts
@@ -1,0 +1,506 @@
+/**
+ * Central chat state manager — owns per-session state and processes gateway
+ * events so that multiple screens can subscribe without duplicating listeners.
+ *
+ * Migrated from apps/mobile/src/hooks/useChat.ts event handling logic.
+ */
+import type {
+  GatewayClient,
+  EventFrame,
+  ChatMessage,
+  ToolCall,
+} from "@intelli-claw/shared";
+
+// ─── Re-export types originally defined in useChat ───
+
+export interface DisplayMessage {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  timestamp: string;
+  toolCalls: ToolCall[];
+  streaming?: boolean;
+  /** Local image URIs for user-sent attachments (display only) */
+  imageUris?: string[];
+}
+
+export type AgentStatus =
+  | { phase: "idle" }
+  | { phase: "thinking" }
+  | { phase: "writing" }
+  | { phase: "tool"; toolName: string };
+
+// ─── Internal state per session ───
+
+export interface ChatState {
+  messages: DisplayMessage[];
+  streaming: boolean;
+  agentStatus: AgentStatus;
+  loading: boolean;
+  // internal
+  streamBuf: {
+    id: string;
+    content: string;
+    toolCalls: Map<string, ToolCall>;
+  } | null;
+  runId: string | null;
+  historyLoaded: boolean;
+  lastAccessedAt: number;
+}
+
+/** Messages matching this pattern are housekeeping noise — hide from the user. */
+const HIDDEN_RE =
+  /^(NO_REPLY|HEARTBEAT_OK|NO_)\s*$|^System:|^\[System|Pre-compaction memory flush|^Read HEARTBEAT\.md|reply with NO_REPLY|Store durable memories now/;
+
+const STREAMING_TIMEOUT_MS = 45_000;
+
+function createDefaultState(): ChatState {
+  return {
+    messages: [],
+    streaming: false,
+    agentStatus: { phase: "idle" },
+    loading: false,
+    streamBuf: null,
+    runId: null,
+    historyLoaded: false,
+    lastAccessedAt: Date.now(),
+  };
+}
+
+// ─── ChatStateManager ───
+
+export class ChatStateManager {
+  private states = new Map<string, ChatState>();
+  private subscribers = new Map<string, Set<() => void>>();
+  private eventUnsub: (() => void) | null = null;
+  private streamingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  // ── GatewayClient binding ──
+
+  bind(client: GatewayClient): void {
+    this.unbind();
+    this.eventUnsub = client.onEvent((frame: EventFrame) => {
+      this.handleEvent(frame);
+    });
+  }
+
+  unbind(): void {
+    if (this.eventUnsub) {
+      this.eventUnsub();
+      this.eventUnsub = null;
+    }
+    // Clear all streaming timers
+    for (const timer of this.streamingTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.streamingTimers.clear();
+  }
+
+  // ── State access ──
+
+  getState(sessionKey: string): ChatState {
+    let s = this.states.get(sessionKey);
+    if (!s) {
+      s = createDefaultState();
+      this.states.set(sessionKey, s);
+    }
+    s.lastAccessedAt = Date.now();
+    return s;
+  }
+
+  // ── Subscription (for useSyncExternalStore) ──
+
+  subscribe(sessionKey: string, listener: () => void): () => void {
+    let subs = this.subscribers.get(sessionKey);
+    if (!subs) {
+      subs = new Set();
+      this.subscribers.set(sessionKey, subs);
+    }
+    subs.add(listener);
+    return () => {
+      subs!.delete(listener);
+      if (subs!.size === 0) {
+        this.subscribers.delete(sessionKey);
+      }
+    };
+  }
+
+  // ── History loading (lazy, one-shot per session) ──
+
+  async loadHistory(client: GatewayClient, sessionKey: string): Promise<void> {
+    const state = this.getState(sessionKey);
+    if (state.historyLoaded) return;
+    state.historyLoaded = true;
+
+    this.mutate(sessionKey, (s) => {
+      s.loading = true;
+    });
+
+    try {
+      const res = await client.request<{ messages: ChatMessage[] }>(
+        "chat.history",
+        { sessionKey, limit: 100 },
+      );
+      const histMsgs: DisplayMessage[] = (res?.messages || [])
+        .filter((m) => {
+          if (m.role !== "user" && m.role !== "assistant") return false;
+          const blocks = m.content as any;
+          const raw =
+            typeof m.content === "string"
+              ? m.content
+              : Array.isArray(blocks)
+                ? blocks.map((b: any) => b?.text || "").join("")
+                : String(m.content || "");
+          return !HIDDEN_RE.test(raw.trim());
+        })
+        .map((m, i) => {
+          const blocks = m.content as any;
+          let text =
+            typeof m.content === "string"
+              ? m.content
+              : Array.isArray(blocks)
+                ? blocks.map((b: any) => b?.text || "").join("")
+                : String(m.content || "");
+          text = text.replace(/\n{3,}/g, "\n\n").trim();
+          return {
+            id: `hist-${i}`,
+            role: m.role as "user" | "assistant",
+            content: text,
+            timestamp: m.timestamp || new Date().toISOString(),
+            toolCalls: m.toolCalls || [],
+          };
+        });
+
+      this.mutate(sessionKey, (s) => {
+        s.messages = histMsgs;
+        s.loading = false;
+      });
+    } catch (err) {
+      console.error("[ChatStateManager] history error:", err);
+      this.mutate(sessionKey, (s) => {
+        s.loading = false;
+      });
+    }
+  }
+
+  // ── Memory management ──
+
+  /**
+   * Evict sessions that haven't been accessed in the last N ms and have no
+   * active subscribers.  Called externally (e.g. on a timer or navigation).
+   */
+  trimInactive(maxAgeMs = 5 * 60_000): void {
+    const now = Date.now();
+    for (const [key, state] of this.states) {
+      const subs = this.subscribers.get(key);
+      if ((!subs || subs.size === 0) && now - state.lastAccessedAt > maxAgeMs) {
+        this.states.delete(key);
+        this.clearStreamingTimeout(key);
+      }
+    }
+  }
+
+  /**
+   * Append a user message to the session.  Called from useChat.sendMessage
+   * so the optimistic message shows immediately.
+   */
+  appendUserMessage(sessionKey: string, msg: DisplayMessage): void {
+    this.mutate(sessionKey, (s) => {
+      s.messages = [...s.messages, msg];
+    });
+  }
+
+  /**
+   * Return the current runId for a session (used by abort).
+   */
+  getRunId(sessionKey: string): string | null {
+    return this.getState(sessionKey).runId;
+  }
+
+  // ══════════════════════════════════════════════════════════════════════
+  // Private — event handling (migrated from useChat.ts lines 130-283)
+  // ══════════════════════════════════════════════════════════════════════
+
+  private handleEvent(frame: EventFrame): void {
+    if (frame.event !== "agent") return;
+
+    const raw = frame.payload as Record<string, unknown>;
+    const stream = raw.stream as string | undefined;
+    const data = raw.data as Record<string, unknown> | undefined;
+
+    // Determine which session this event belongs to (#48)
+    const evtSessionKey = (raw.sessionKey ?? data?.sessionKey) as
+      | string
+      | undefined;
+    if (!evtSessionKey) return; // Cannot route without a session key
+
+    const sessionKey = evtSessionKey;
+
+    // ── assistant text delta ──
+    if (
+      stream === "assistant" &&
+      (typeof data?.delta === "string" || typeof data?.text === "string")
+    ) {
+      const chunk =
+        (data?.delta as string | undefined) ?? (data?.text as string);
+
+      this.mutate(sessionKey, (s) => {
+        s.streaming = true;
+        s.agentStatus = { phase: "writing" };
+
+        if (!s.streamBuf) {
+          s.streamBuf = {
+            id: `stream-${Date.now()}`,
+            content: "",
+            toolCalls: new Map(),
+          };
+        }
+        s.streamBuf.content += chunk;
+
+        const snap = s.streamBuf;
+        const msg: DisplayMessage = {
+          id: snap.id,
+          role: "assistant",
+          content: snap.content,
+          timestamp: new Date().toISOString(),
+          toolCalls: Array.from(snap.toolCalls.values()),
+          streaming: true,
+        };
+        const idx = s.messages.findIndex((m) => m.id === snap.id);
+        if (idx >= 0) {
+          s.messages = [...s.messages];
+          s.messages[idx] = msg;
+        } else {
+          s.messages = [...s.messages, msg];
+        }
+      });
+
+      this.startStreamingTimeout(sessionKey);
+
+      // ── tool start ──
+    } else if (stream === "tool-start" && data) {
+      const callId = String(data.toolCallId || data.callId || "");
+      const name = String(data.name || data.tool || "");
+
+      this.mutate(sessionKey, (s) => {
+        s.agentStatus = { phase: "tool", toolName: name };
+
+        if (!s.streamBuf) {
+          s.streamBuf = {
+            id: `stream-${Date.now()}`,
+            content: "",
+            toolCalls: new Map(),
+          };
+        }
+        s.streamBuf.toolCalls.set(callId, {
+          callId,
+          name,
+          status: "running",
+        });
+
+        const snap = s.streamBuf;
+        const msg: DisplayMessage = {
+          id: snap.id,
+          role: "assistant",
+          content: snap.content,
+          timestamp: new Date().toISOString(),
+          toolCalls: Array.from(snap.toolCalls.values()),
+          streaming: true,
+        };
+        const idx = s.messages.findIndex((m) => m.id === snap.id);
+        if (idx >= 0) {
+          s.messages = [...s.messages];
+          s.messages[idx] = msg;
+        } else {
+          s.messages = [...s.messages, msg];
+        }
+      });
+
+      // ── tool end ──
+    } else if (stream === "tool-end" && data) {
+      const callId = String(data.toolCallId || data.callId || "");
+      const result = data.result as string | undefined;
+
+      this.mutate(sessionKey, (s) => {
+        s.agentStatus = { phase: "thinking" };
+
+        if (s.streamBuf) {
+          const tc = s.streamBuf.toolCalls.get(callId);
+          if (tc) {
+            tc.status = "done";
+            tc.result = result;
+          }
+          const snap = s.streamBuf;
+          const idx = s.messages.findIndex((m) => m.id === snap.id);
+          if (idx >= 0) {
+            s.messages = [...s.messages];
+            s.messages[idx] = {
+              ...s.messages[idx],
+              toolCalls: Array.from(snap.toolCalls.values()),
+            };
+          }
+        }
+      });
+
+      // ── lifecycle start ──
+    } else if (stream === "lifecycle" && data?.phase === "start") {
+      this.mutate(sessionKey, (s) => {
+        s.streaming = true;
+        s.runId = (raw.runId as string) ?? null;
+        s.agentStatus = { phase: "thinking" };
+      });
+      this.startStreamingTimeout(sessionKey);
+
+      // ── lifecycle end ──
+    } else if (stream === "lifecycle" && data?.phase === "end") {
+      this.clearStreamingTimeout(sessionKey);
+
+      this.mutate(sessionKey, (s) => {
+        s.streaming = false;
+        s.agentStatus = { phase: "idle" };
+
+        if (s.streamBuf) {
+          const finalId = s.streamBuf.id;
+          const finalContent = s.streamBuf.content;
+          const finalTools = Array.from(s.streamBuf.toolCalls.values());
+          if (HIDDEN_RE.test(finalContent.trim())) {
+            s.messages = s.messages.filter((m) => m.id !== finalId);
+          } else {
+            s.messages = s.messages.map((m) =>
+              m.id === finalId
+                ? {
+                    ...m,
+                    content: finalContent,
+                    toolCalls: finalTools,
+                    streaming: false,
+                  }
+                : m,
+            );
+          }
+          s.streamBuf = null;
+        }
+      });
+
+      // ── done/end/finish (alternative end signals) ──
+    } else if (
+      stream === "done" ||
+      stream === "end" ||
+      stream === "finish"
+    ) {
+      this.clearStreamingTimeout(sessionKey);
+
+      this.mutate(sessionKey, (s) => {
+        s.streaming = false;
+        s.agentStatus = { phase: "idle" };
+
+        if (s.streamBuf) {
+          const finalId = s.streamBuf.id;
+          const finalContent =
+            (data?.text as string) || s.streamBuf.content;
+          const finalTools = Array.from(s.streamBuf.toolCalls.values());
+          if (HIDDEN_RE.test(finalContent.trim())) {
+            s.messages = s.messages.filter((m) => m.id !== finalId);
+          } else {
+            s.messages = s.messages.map((m) =>
+              m.id === finalId
+                ? {
+                    ...m,
+                    content: finalContent,
+                    toolCalls: finalTools,
+                    streaming: false,
+                  }
+                : m,
+            );
+          }
+          s.streamBuf = null;
+        }
+      });
+
+      // ── error ──
+    } else if (stream === "error") {
+      this.clearStreamingTimeout(sessionKey);
+      const errMsg = String(
+        data?.message || data?.error || "Unknown error",
+      );
+
+      this.mutate(sessionKey, (s) => {
+        s.streaming = false;
+        s.agentStatus = { phase: "idle" };
+
+        if (s.streamBuf) {
+          const errId = s.streamBuf.id;
+          s.messages = s.messages.map((m) =>
+            m.id === errId
+              ? {
+                  ...m,
+                  content: m.content + `\n\n**Error:** ${errMsg}`,
+                  streaming: false,
+                }
+              : m,
+          );
+          s.streamBuf = null;
+        }
+      });
+    }
+  }
+
+  // ── Helpers ──
+
+  /**
+   * Mutate a session's state and notify subscribers.
+   * The callback receives the current ChatState and may modify it in-place.
+   * After the callback, we replace the state reference so that
+   * useSyncExternalStore detects the change via identity comparison.
+   */
+  private mutate(
+    sessionKey: string,
+    fn: (state: ChatState) => void,
+  ): void {
+    const prev = this.getState(sessionKey);
+    fn(prev);
+    // Replace the reference so getSnapshot returns a new object
+    const next = { ...prev };
+    this.states.set(sessionKey, next);
+    this.notify(sessionKey);
+  }
+
+  private notify(sessionKey: string): void {
+    const subs = this.subscribers.get(sessionKey);
+    if (subs) {
+      for (const cb of subs) cb();
+    }
+  }
+
+  private startStreamingTimeout(sessionKey: string): void {
+    this.clearStreamingTimeout(sessionKey);
+    this.streamingTimers.set(
+      sessionKey,
+      setTimeout(() => {
+        console.warn(
+          "[ChatStateManager] streaming timeout — forcing idle for",
+          sessionKey,
+        );
+        this.mutate(sessionKey, (s) => {
+          s.streaming = false;
+          s.agentStatus = { phase: "idle" };
+          if (s.streamBuf) {
+            const finalId = s.streamBuf.id;
+            s.messages = s.messages.map((m) =>
+              m.id === finalId ? { ...m, streaming: false } : m,
+            );
+            s.streamBuf = null;
+          }
+        });
+        this.streamingTimers.delete(sessionKey);
+      }, STREAMING_TIMEOUT_MS),
+    );
+  }
+
+  private clearStreamingTimeout(sessionKey: string): void {
+    const timer = this.streamingTimers.get(sessionKey);
+    if (timer) {
+      clearTimeout(timer);
+      this.streamingTimers.delete(sessionKey);
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-router:
         specifier: ~6.0.23
-        version: 6.0.23(vic2gjw2l4x6fitzpirsdenwhm)
+        version: 6.0.23(3e4e2dd8aafadb4e44f11e670c0ecab4)
       expo-secure-store:
         specifier: ~15.0.8
         version: 15.0.8(expo@54.0.33)
@@ -171,6 +171,9 @@ importers:
       react-native-mmkv:
         specifier: ^3.2.0
         version: 3.3.3(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-pager-view:
+        specifier: ^8.0.0
+        version: 8.0.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-reanimated:
         specifier: ~4.1.6
         version: 4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -6471,6 +6474,12 @@ packages:
       react: 19.1.0
       react-native: '*'
 
+  react-native-pager-view@8.0.0:
+    resolution: {integrity: sha512-oAwlWT1lhTkIs9HhODnjNNl/owxzn9DP1MbP+az6OTUdgbmzA16Up83sBH8NRKwrH8rNm7iuWnX1qMqiiWOLhg==}
+    peerDependencies:
+      react: 19.1.0
+      react-native: '*'
+
   react-native-reanimated@4.1.6:
     resolution: {integrity: sha512-F+ZJBYiok/6Jzp1re75F/9aLzkgoQCOh4yxrnwATa8392RvM3kx+fiXXFvwcgE59v48lMwd9q0nzF1oJLXpfxQ==}
     peerDependencies:
@@ -8868,7 +8877,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.19.0
     optionalDependencies:
-      expo-router: 6.0.23(vic2gjw2l4x6fitzpirsdenwhm)
+      expo-router: 6.0.23(3e4e2dd8aafadb4e44f11e670c0ecab4)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -12429,7 +12438,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
-  expo-router@6.0.23(vic2gjw2l4x6fitzpirsdenwhm):
+  expo-router@6.0.23(3e4e2dd8aafadb4e44f11e670c0ecab4):
     dependencies:
       '@expo/metro-runtime': 5.0.5(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
       '@expo/schema-utils': 0.1.8
@@ -15000,6 +15009,11 @@ snapshots:
       react-native-fit-image: 1.5.5
 
   react-native-mmkv@3.3.3(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+
+  react-native-pager-view@8.0.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)


### PR DESCRIPTION
## Summary
- PagerView로 에이전트 간 네이티브 스와이프 전환
- AgentTabBar: 애니메이션 인디케이터, 스트리밍 펄스, 안 읽은 메시지 뱃지
- ChatStateManager: 중앙 상태 관리로 에이전트별 독립 채팅 상태 유지
- 비활성 에이전트의 스트리밍도 백그라운드 수신

## Architecture
```
GatewayClient.onEvent -> ChatStateManager (single listener)
                              |
                   Map<sessionKey, ChatState>
                              |
                  useChat("A")  useChat("B")  useChat("C")
```

## Changed files
| File | Change |
|------|--------|
| `stores/chatStateManager.ts` | (new) Central state manager |
| `stores/ChatStateProvider.tsx` | (new) React context provider |
| `hooks/useChatState.ts` | (new) Thin subscription hook |
| `hooks/useChat.ts` | Refactored: delegates to central manager |
| `components/chat/AgentTabBar.tsx` | (new) Tab bar with animations |
| `components/chat/AgentChatPage.tsx` | (new) Per-agent chat page |
| `app/(tabs)/index.tsx` | Rewritten with PagerView |
| `app/_layout.tsx` | Added ChatStateProvider |

## Test plan
- [ ] 좌우 스와이프로 에이전트 간 전환 확인
- [ ] 탭 바 탭으로 에이전트 전환 확인
- [ ] 에이전트 전환 후 복귀 시 메시지/스크롤 상태 유지 확인
- [ ] 비활성 에이전트에서 스트리밍 수신 확인 (탭 바 펄스 표시)
- [ ] SessionSwitcher로 특정 세션 선택 시 해당 에이전트 페이지로 이동
- [ ] typecheck 통과 확인

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)