### PR TITLE
fix(#157): 텍스트 파일 첨부 시 에이전트가 파일 내용을 인식하지 못하는 문제

### DIFF
--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain } from "electron";
-import { handleMediaServe, handleMediaRange, handleMediaInfo } from "./media-handler";
+import { handleMediaServe, handleMediaRange, handleMediaInfo, handleMediaUpload } from "./media-handler";
 import { handleShowcaseList, handleShowcaseServe } from "./showcase-handler";
 
 export function registerIpcHandlers() {
@@ -8,6 +8,9 @@ export function registerIpcHandlers() {
   ipcMain.handle("media:serve", (_event, filePath: string) => handleMediaServe(filePath));
   ipcMain.handle("media:range", (_event, filePath: string, start: number, end: number) =>
     handleMediaRange(filePath, start, end),
+  );
+  ipcMain.handle("media:upload", (_event, data: string, mimeType: string, fileName?: string) =>
+    handleMediaUpload(data, mimeType, fileName),
   );
   ipcMain.handle("showcase:list", () => handleShowcaseList());
   ipcMain.handle("showcase:serve", (_event, relPath: string) => handleShowcaseServe(relPath));

--- a/apps/desktop/src/main/media-handler.ts
+++ b/apps/desktop/src/main/media-handler.ts
@@ -1,5 +1,7 @@
-import { readFile, stat, open } from "node:fs/promises";
-import { extname, basename } from "node:path";
+import { readFile, stat, open, mkdir, writeFile } from "node:fs/promises";
+import { extname, basename, join } from "node:path";
+import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
 
 const MIME_MAP: Record<string, string> = {
   png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", gif: "image/gif",
@@ -80,4 +82,37 @@ export async function handleMediaRange(
     end: actualEnd,
     total: info.size,
   };
+}
+
+// ---- #157: File upload (same as server api-server.ts upload handler) ----
+
+const UPLOAD_DIR = join(homedir(), ".openclaw", "media", "uploads");
+
+const UPLOAD_MIME_TO_EXT: Record<string, string> = {
+  "image/jpeg": "jpg", "image/png": "png", "image/gif": "gif",
+  "image/webp": "webp", "image/svg+xml": "svg", "image/bmp": "bmp",
+  "text/plain": "txt", "text/csv": "csv", "text/markdown": "md",
+  "text/xml": "xml", "text/yaml": "yaml", "text/html": "html",
+  "text/tab-separated-values": "tsv",
+  "application/json": "json", "application/xml": "xml",
+  "application/pdf": "pdf",
+};
+
+export async function handleMediaUpload(
+  data: string,
+  mimeType: string,
+  fileName?: string,
+): Promise<{ path: string }> {
+  const ext = UPLOAD_MIME_TO_EXT[mimeType] || mimeType.split("/")[1] || "bin";
+  const uuid = randomUUID();
+  const outName = fileName
+    ? `${uuid}-${fileName.replace(/[^a-zA-Z0-9._-]/g, "_")}`
+    : `${uuid}.${ext}`;
+  const outPath = join(UPLOAD_DIR, outName);
+
+  await mkdir(UPLOAD_DIR, { recursive: true });
+  const buffer = Buffer.from(data, "base64");
+  await writeFile(outPath, buffer);
+
+  return { path: outPath };
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -12,6 +12,8 @@ const electronAPI = {
     mediaServe: (filePath: string) => ipcRenderer.invoke("media:serve", filePath),
     mediaRange: (filePath: string, start: number, end: number) =>
       ipcRenderer.invoke("media:range", filePath, start, end),
+    mediaUpload: (data: string, mimeType: string, fileName?: string) =>
+      ipcRenderer.invoke("media:upload", data, mimeType, fileName) as Promise<{ path: string }>,
     showcaseList: () => ipcRenderer.invoke("showcase:list"),
     showcaseServe: (relPath: string) => ipcRenderer.invoke("showcase:serve", relPath),
   },

--- a/apps/server/src/__tests__/media-upload.test.ts
+++ b/apps/server/src/__tests__/media-upload.test.ts
@@ -108,13 +108,23 @@ describe("POST /api/media/upload", () => {
     expect(getRes.contentType).toContain("image/jpeg");
   });
 
-  it("rejects non-image mime types", async () => {
+  it("rejects disallowed mime types (legacy test — updated for #157)", async () => {
     const { status, data } = await postJson(`${baseUrl}/api/media/upload`, {
       data: btoa("hello world"),
-      mimeType: "application/pdf",
+      mimeType: "application/x-executable",
     });
     expect(status).toBe(400);
-    expect(data.error).toContain("image");
+    expect(data.error).toBeDefined();
+  });
+
+  it("accepts application/pdf uploads (#157)", async () => {
+    const { status, data } = await postJson(`${baseUrl}/api/media/upload`, {
+      data: btoa("%PDF-1.4 fake"),
+      mimeType: "application/pdf",
+      fileName: "doc.pdf",
+    });
+    expect(status).toBe(200);
+    expect((data.path as string)).toMatch(/\.pdf$/);
   });
 
   it("rejects missing data", async () => {
@@ -161,6 +171,118 @@ describe("POST /api/media/upload", () => {
     });
     expect(status).toBe(200);
     expect((data.path as string)).toMatch(/\.webp$/);
+  });
+
+  // ---- #157: Text file upload support ----
+
+  it("accepts text/csv uploads", async () => {
+    const csvContent = Buffer.from("name,age\nAlice,30\nBob,25").toString("base64");
+    const { status, data } = await postJson(`${baseUrl}/api/media/upload`, {
+      data: csvContent,
+      mimeType: "text/csv",
+      fileName: "data.csv",
+    });
+    expect(status).toBe(200);
+    expect(data.path).toBeDefined();
+    expect((data.path as string)).toMatch(/\.csv$/);
+    // Verify file content is correct
+    const saved = await readFile(data.path as string, "utf-8");
+    expect(saved).toBe("name,age\nAlice,30\nBob,25");
+  });
+
+  it("accepts text/plain uploads", async () => {
+    const txtContent = Buffer.from("Hello, world!").toString("base64");
+    const { status, data } = await postJson(`${baseUrl}/api/media/upload`, {
+      data: txtContent,
+      mimeType: "text/plain",
+      fileName: "notes.txt",
+    });
+    expect(status).toBe(200);
+    expect((data.path as string)).toMatch(/\.txt$/);
+  });
+
+  it("accepts application/json uploads", async () => {
+    const jsonContent = Buffer.from(JSON.stringify({ key: "value" })).toString("base64");
+    const { status, data } = await postJson(`${baseUrl}/api/media/upload`, {
+      data: jsonContent,
+      mimeType: "application/json",
+      fileName: "config.json",
+    });
+    expect(status).toBe(200);
+    expect((data.path as string)).toMatch(/\.json$/);
+  });
+
+  it("accepts text/markdown uploads", async () => {
+    const mdContent = Buffer.from("# Title\n\nParagraph").toString("base64");
+    const { status, data } = await postJson(`${baseUrl}/api/media/upload`, {
+      data: mdContent,
+      mimeType: "text/markdown",
+      fileName: "readme.md",
+    });
+    expect(status).toBe(200);
+    expect((data.path as string)).toMatch(/\.md$/);
+  });
+
+  it("accepts text/xml uploads", async () => {
+    const xmlContent = Buffer.from("<root><item>1</item></root>").toString("base64");
+    const { status, data } = await postJson(`${baseUrl}/api/media/upload`, {
+      data: xmlContent,
+      mimeType: "text/xml",
+      fileName: "data.xml",
+    });
+    expect(status).toBe(200);
+    expect((data.path as string)).toMatch(/\.xml$/);
+  });
+
+  it("accepts text/yaml uploads", async () => {
+    const yamlContent = Buffer.from("key: value\nlist:\n  - a\n  - b").toString("base64");
+    const { status, data } = await postJson(`${baseUrl}/api/media/upload`, {
+      data: yamlContent,
+      mimeType: "text/yaml",
+      fileName: "config.yaml",
+    });
+    expect(status).toBe(200);
+    expect((data.path as string)).toMatch(/\.yaml$/);
+  });
+
+  it("accepts text/tab-separated-values uploads", async () => {
+    const tsvContent = Buffer.from("name\tage\nAlice\t30").toString("base64");
+    const { status, data } = await postJson(`${baseUrl}/api/media/upload`, {
+      data: tsvContent,
+      mimeType: "text/tab-separated-values",
+      fileName: "data.tsv",
+    });
+    expect(status).toBe(200);
+    expect((data.path as string)).toMatch(/\.tsv$/);
+  });
+
+  it("rejects disallowed mime types (e.g. application/x-executable)", async () => {
+    const { status, data } = await postJson(`${baseUrl}/api/media/upload`, {
+      data: Buffer.from("MZ").toString("base64"),
+      mimeType: "application/x-executable",
+    });
+    expect(status).toBe(400);
+    expect(data.error).toBeDefined();
+  });
+
+  it("serves uploaded text file via GET /api/media", async () => {
+    const csvContent = Buffer.from("col1,col2\n1,2").toString("base64");
+    const { data } = await postJson(`${baseUrl}/api/media/upload`, {
+      data: csvContent,
+      mimeType: "text/csv",
+      fileName: "serve-test.csv",
+    });
+    const filePath = data.path as string;
+
+    const getRes = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+      http.get(`${baseUrl}/api/media?path=${encodeURIComponent(filePath)}`, (res) => {
+        let body = "";
+        res.on("data", (c) => (body += c));
+        res.on("end", () => resolve({ status: res.statusCode!, body }));
+      }).on("error", reject);
+    });
+    expect(getRes.status).toBe(200);
+    expect(getRes.body).toBe("col1,col2\n1,2");
   });
 
   it("handles CORS preflight for upload endpoint", async () => {

--- a/apps/server/src/api-server.ts
+++ b/apps/server/src/api-server.ts
@@ -92,10 +92,20 @@ function validatePath(p: string | null): string | null {
 const UPLOAD_DIR = join(homedir(), ".openclaw", "media", "uploads");
 const MAX_UPLOAD_B64 = 10 * 1024 * 1024; // 10 MB base64 limit
 const MIME_TO_EXT: Record<string, string> = {
+  // Images
   "image/jpeg": "jpg", "image/png": "png", "image/gif": "gif",
   "image/webp": "webp", "image/svg+xml": "svg", "image/bmp": "bmp",
   "image/tiff": "tiff",
+  // Text / structured data (#157)
+  "text/plain": "txt", "text/csv": "csv", "text/markdown": "md",
+  "text/xml": "xml", "text/yaml": "yaml", "text/html": "html",
+  "text/tab-separated-values": "tsv",
+  "application/json": "json", "application/xml": "xml",
+  "application/pdf": "pdf",
 };
+
+/** MIME prefixes / exact types allowed for upload. Rejects executables, archives, etc. */
+const ALLOWED_MIME_PREFIXES = ["image/", "text/", "application/json", "application/xml", "application/pdf"];
 
 async function handleMediaUpload(req: http.IncomingMessage, res: http.ServerResponse) {
   const chunks: Buffer[] = [];
@@ -127,9 +137,9 @@ async function handleMediaUpload(req: http.IncomingMessage, res: http.ServerResp
     return;
   }
 
-  if (!mimeType.startsWith("image/")) {
+  if (!ALLOWED_MIME_PREFIXES.some((p) => mimeType.startsWith(p))) {
     res.writeHead(400, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "Only image types are accepted" }));
+    res.end(JSON.stringify({ error: `MIME type '${mimeType}' is not allowed. Accepted: image/*, text/*, application/json, application/xml, application/pdf` }));
     return;
   }
 

--- a/apps/web/src/__tests__/file-attachments-text.test.ts
+++ b/apps/web/src/__tests__/file-attachments-text.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import {
+  attachmentToPayload,
+  type ChatAttachment,
+  type AttachmentPayloadResult,
+  isTextFile,
+  TEXT_INLINE_LIMIT,
+} from "@/components/chat/file-attachments";
+
+/**
+ * #157: Text file attachment handling tests (TDD)
+ *
+ * Text files (CSV, TXT, JSON, MD, etc.) should:
+ * 1. Be identified by isTextFile()
+ * 2. Have content extracted and returned as prependText (inline) for small files
+ * 3. Still produce a payload for server upload
+ * 4. Truncate content at TEXT_INLINE_LIMIT for very large files
+ */
+
+function makeFile(name: string, content: string, type?: string): File {
+  return new File([content], name, { type: type || "" });
+}
+
+function makeAttachment(
+  file: File,
+  overrides?: Partial<ChatAttachment>,
+): ChatAttachment {
+  return {
+    id: `test-${Date.now()}`,
+    file,
+    type: "file",
+    ...overrides,
+  };
+}
+
+// ---- isTextFile ----
+
+describe("isTextFile", () => {
+  it.each([
+    ["data.csv", true],
+    ["notes.txt", true],
+    ["config.json", true],
+    ["readme.md", true],
+    ["changelog.mdx", true],
+    ["log.log", true],
+    ["data.xml", true],
+    ["config.yaml", true],
+    ["config.yml", true],
+    ["data.tsv", true],
+    ["code.py", false],
+    ["photo.jpg", false],
+    ["archive.zip", false],
+    ["document.pdf", false],
+    ["app.exe", false],
+    ["noext", false],
+  ])("isTextFile('%s') → %s", (name, expected) => {
+    expect(isTextFile(name)).toBe(expected);
+  });
+});
+
+// ---- attachmentToPayload for text files ----
+
+describe("attachmentToPayload — text files (#157)", () => {
+  it("extracts CSV content as prependText", async () => {
+    const csv = "name,age\nAlice,30\nBob,25";
+    const att = makeAttachment(makeFile("data.csv", csv, "text/csv"));
+    const result = await attachmentToPayload(att);
+
+    expect(result.prependText).toBeDefined();
+    expect(result.prependText).toContain("data.csv");
+    expect(result.prependText).toContain("name,age");
+    expect(result.prependText).toContain("Alice,30");
+  });
+
+  it("extracts TXT content as prependText", async () => {
+    const txt = "Hello world, this is a text file.";
+    const att = makeAttachment(makeFile("notes.txt", txt, "text/plain"));
+    const result = await attachmentToPayload(att);
+
+    expect(result.prependText).toBeDefined();
+    expect(result.prependText).toContain("notes.txt");
+    expect(result.prependText).toContain(txt);
+  });
+
+  it("extracts JSON content as prependText", async () => {
+    const json = '{"key": "value", "count": 42}';
+    const att = makeAttachment(makeFile("config.json", json, "application/json"));
+    const result = await attachmentToPayload(att);
+
+    expect(result.prependText).toBeDefined();
+    expect(result.prependText).toContain("config.json");
+    expect(result.prependText).toContain('"key"');
+  });
+
+  it("extracts MD content as prependText", async () => {
+    const md = "# Title\n\nSome paragraph.";
+    const att = makeAttachment(makeFile("readme.md", md, "text/markdown"));
+    const result = await attachmentToPayload(att);
+
+    expect(result.prependText).toBeDefined();
+    expect(result.prependText).toContain("readme.md");
+    expect(result.prependText).toContain("# Title");
+  });
+
+  it("extracts YAML content as prependText", async () => {
+    const yaml = "key: value\nlist:\n  - a\n  - b";
+    const att = makeAttachment(makeFile("config.yaml", yaml, "text/yaml"));
+    const result = await attachmentToPayload(att);
+
+    expect(result.prependText).toBeDefined();
+    expect(result.prependText).toContain("config.yaml");
+    expect(result.prependText).toContain("key: value");
+  });
+
+  it("truncates large text files at TEXT_INLINE_LIMIT", async () => {
+    const largeContent = "x".repeat(TEXT_INLINE_LIMIT + 10_000);
+    const att = makeAttachment(makeFile("big.csv", largeContent, "text/csv"));
+    const result = await attachmentToPayload(att);
+
+    expect(result.prependText).toBeDefined();
+    // Should contain truncation indicator
+    expect(result.prependText!.length).toBeLessThan(largeContent.length + 500);
+    expect(result.prependText).toContain("…truncated");
+  });
+
+  it("also produces a payload for server upload", async () => {
+    const csv = "col1,col2\n1,2";
+    const att = makeAttachment(makeFile("small.csv", csv, "text/csv"));
+    const result = await attachmentToPayload(att);
+
+    // Should have a payload for upload
+    expect(result.payloads.length).toBe(1);
+    expect(result.payloads[0].fileName).toBe("small.csv");
+    expect(result.payloads[0].mimeType).toBe("text/csv");
+    expect(result.payloads[0].content).toBeTruthy(); // base64
+  });
+
+  it("wraps content in code block with file name header", async () => {
+    const txt = "line1\nline2";
+    const att = makeAttachment(makeFile("test.txt", txt, "text/plain"));
+    const result = await attachmentToPayload(att);
+
+    expect(result.prependText).toContain("```");
+    expect(result.prependText).toContain("📎");
+  });
+
+  it("does NOT inline-extract non-text files (e.g. .exe, .zip)", async () => {
+    const att = makeAttachment(
+      makeFile("app.exe", "binary-stuff", "application/octet-stream"),
+    );
+    const result = await attachmentToPayload(att);
+
+    // No text extraction — just raw payload
+    expect(result.prependText).toBeUndefined();
+    expect(result.payloads.length).toBe(1);
+  });
+
+  it("handles Electron filePath hint for text files", async () => {
+    const att = makeAttachment(
+      makeFile("data.csv", "a,b\n1,2", "text/csv"),
+      { filePath: "/Users/test/data.csv" },
+    );
+    const result = await attachmentToPayload(att);
+
+    // Should include the file path in prependText for agent read access
+    expect(result.prependText).toContain("/Users/test/data.csv");
+  });
+
+  it("handles empty text files gracefully", async () => {
+    const att = makeAttachment(makeFile("empty.txt", "", "text/plain"));
+    const result = await attachmentToPayload(att);
+
+    // Should still have a payload (the file exists even if empty)
+    expect(result.payloads.length).toBe(1);
+    // prependText can be undefined or contain just the header
+    // No crash is the main assertion
+  });
+});

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -581,22 +581,28 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
         const pdfTexts = results.map((r) => r.prependText).filter(Boolean).join("\n\n");
         const pathHintText = pdfPathHints.join("\n");
 
-        // Upload images to server for permanent storage (#110)
+        // Upload files to server for permanent storage (#110, #157)
         const mediaLines: string[] = [];
+        const filePathLines: string[] = [];
         if (platform.mediaUpload) {
           for (const p of payloads) {
-            if (p.mimeType?.startsWith("image/") && p.content) {
+            if (p.content) {
               try {
                 const { path: savedPath } = await platform.mediaUpload(p.content, p.mimeType, p.fileName);
-                mediaLines.push(`MEDIA:${savedPath}`);
+                if (p.mimeType?.startsWith("image/")) {
+                  mediaLines.push(`MEDIA:${savedPath}`);
+                } else {
+                  // Non-image files: provide path so agent can read via `read` tool
+                  filePathLines.push(`📎 [${p.fileName}] ${savedPath}`);
+                }
               } catch (err) {
-                console.warn("[AWF] Image upload failed, sending inline:", err);
+                console.warn("[AWF] File upload failed, sending inline:", err);
               }
             }
           }
         }
 
-        const userMsg = [text, pathHintText, pdfTexts, ...mediaLines].filter(Boolean).join("\n\n") || (payloads.length > 0 ? "(image)" : "");
+        const userMsg = [text, pathHintText, pdfTexts, ...mediaLines, ...filePathLines].filter(Boolean).join("\n\n") || (payloads.length > 0 ? "(첨부 파일)" : "");
 
         const displayAtts = await Promise.all(
           attachments.map(async (att) => {

--- a/apps/web/src/components/chat/file-attachments.tsx
+++ b/apps/web/src/components/chat/file-attachments.tsx
@@ -98,6 +98,22 @@ export async function readTextContent(file: File): Promise<string | undefined> {
   return undefined;
 }
 
+// ---- #157: Text file support ----
+
+/** Extensions recognised as text files whose content can be inlined for agents. */
+const TEXT_EXTS = new Set([
+  "csv", "txt", "json", "md", "mdx", "log", "xml", "yaml", "yml", "tsv",
+]);
+
+/** Maximum characters to inline into the message (50 KB). Larger files are truncated. */
+export const TEXT_INLINE_LIMIT = 50_000;
+
+/** Check whether a file name represents a text file eligible for inline extraction. */
+export function isTextFile(name: string): boolean {
+  const ext = name.split(".").pop()?.toLowerCase();
+  return !!ext && TEXT_EXTS.has(ext);
+}
+
 // ---- Attachment preview bar ----
 
 export function AttachmentPreview({
@@ -424,6 +440,27 @@ export async function attachmentToPayload(
     const target = Math.min(MAX_BASE64_BYTES, IMAGE_COMPRESS_TARGET);
     const { base64, mimeType } = await compressImage(att.file, target);
     return { payloads: [{ fileName: att.file.name, mimeType, content: base64 }] };
+  }
+
+  // --- #157: Text files — extract content inline + keep payload for upload ---
+  if (isTextFile(att.file.name)) {
+    const payload = await rawPayload(att);
+    let prependText: string | undefined;
+
+    try {
+      const rawText = await att.file.text();
+      if (rawText.length > 0) {
+        const truncated = rawText.length > TEXT_INLINE_LIMIT
+          ? rawText.slice(0, TEXT_INLINE_LIMIT) + "\n…truncated"
+          : rawText;
+        const pathHint = att.filePath ? ` ${att.filePath}` : "";
+        prependText = `📎 [${att.file.name}]${pathHint}\n\`\`\`\n${truncated}\n\`\`\``;
+      }
+    } catch {
+      // If text extraction fails, fall through with just the payload
+    }
+
+    return { prependText, payloads: [payload] };
   }
 
   // --- Other files: as-is ---

--- a/apps/web/src/lib/platform/electron.ts
+++ b/apps/web/src/lib/platform/electron.ts
@@ -25,4 +25,8 @@ export const electronPlatform: PlatformAPI = {
     // Showcase files served via custom protocol
     return `intelli-claw://showcase/${encodeURIComponent(relativePath)}`;
   },
+
+  async mediaUpload(data, mimeType, fileName) {
+    return window.electronAPI.platform.mediaUpload(data, mimeType, fileName);
+  },
 };


### PR DESCRIPTION
Closes #157

## Root Cause
- 서버: `image/*` MIME만 업로드 허용 → CSV, TXT 등 거부
- 프론트엔드: 이미지만 `mediaUpload` 호출, 텍스트 파일은 base64로만 전달
- Electron: `mediaUpload` IPC 미구현

## Changes (9 files, +410/-13)
- 서버 MIME 허용 목록 확대 (`image/*`, `text/*`, `application/json`, `application/xml`, `application/pdf`)
- `isTextFile()` 판별 + `attachmentToPayload()` 텍스트 인라인 추출 (50KB 한도)
- `chat-panel.tsx`: 비이미지 파일도 서버 업로드 → 경로를 에이전트에 전달
- Electron `mediaUpload` IPC 핸들러 + preload 바인딩 추가

## Tests
- 프론트엔드 27건 + 서버 10건 신규, 전체 통과
- Vite 빌드 정상