### PR TITLE
fix(#156): 세션 갱신 사유가 항상 '컨텍스트 한도 도달'로만 표시되는 문제

### DIFF
--- a/apps/web/src/__tests__/message-list.test.tsx
+++ b/apps/web/src/__tests__/message-list.test.tsx
@@ -287,7 +287,8 @@ describe("MessageList — display filtering", () => {
       makeAssistantMessage("After"),
     ];
     render(<MessageList messages={messages} loading={false} streaming={false} />);
-    expect(screen.getByText("세션 갱신됨 (컨텍스트 한도 도달)")).toBeInTheDocument();
+    // #156: reason이 없으면 'unknown' → "세션 갱신됨"
+    expect(screen.getByText("세션 갱신됨")).toBeInTheDocument();
   });
 
   it("hides HEARTBEAT_OK messages", () => {
@@ -439,10 +440,34 @@ describe("MessageBubble — system messages", () => {
 // ===================================================================
 
 describe("SessionBoundary", () => {
-  it("renders with correct text", () => {
+  it("renders with correct text (unknown reason → fallback)", () => {
     const messages = [makeBoundaryMessage()];
     render(<MessageList messages={messages} loading={false} streaming={false} />);
+    expect(screen.getByText("세션 갱신됨")).toBeInTheDocument();
+  });
+
+  it("renders context_overflow reason (#156)", () => {
+    const messages = [makeBoundaryMessage({ resetReason: "context_overflow" })];
+    render(<MessageList messages={messages} loading={false} streaming={false} />);
     expect(screen.getByText("세션 갱신됨 (컨텍스트 한도 도달)")).toBeInTheDocument();
+  });
+
+  it("renders daily reason (#156)", () => {
+    const messages = [makeBoundaryMessage({ resetReason: "daily" })];
+    render(<MessageList messages={messages} loading={false} streaming={false} />);
+    expect(screen.getByText("새로운 하루, 새 세션이 시작되었습니다")).toBeInTheDocument();
+  });
+
+  it("renders idle reason (#156)", () => {
+    const messages = [makeBoundaryMessage({ resetReason: "idle" })];
+    render(<MessageList messages={messages} loading={false} streaming={false} />);
+    expect(screen.getByText("장시간 미활동으로 세션이 초기화되었습니다")).toBeInTheDocument();
+  });
+
+  it("renders manual reason (#156)", () => {
+    const messages = [makeBoundaryMessage({ resetReason: "manual" })];
+    render(<MessageList messages={messages} loading={false} streaming={false} />);
+    expect(screen.getByText("새 세션이 시작되었습니다")).toBeInTheDocument();
   });
 
   it("shows 이전 맥락 불러오기 button when onLoadPreviousContext is provided", () => {

--- a/apps/web/src/__tests__/session-reset-reason.test.ts
+++ b/apps/web/src/__tests__/session-reset-reason.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  inferResetReason,
+  resetReasonLabel,
+  type ResetReason,
+  type ResetReasonContext,
+} from "@/lib/gateway/reset-reason";
+
+/**
+ * #156: Session reset reason inference and display (TDD)
+ *
+ * Since the Gateway does not provide a `resetReason` field,
+ * we infer it from available context (token usage, timing, user action).
+ * When Gateway adds `resetReason` in the future, it takes precedence.
+ */
+
+describe("inferResetReason", () => {
+  let realDate: typeof Date;
+
+  beforeEach(() => {
+    realDate = globalThis.Date;
+  });
+
+  afterEach(() => {
+    globalThis.Date = realDate;
+    vi.restoreAllMocks();
+  });
+
+  function mockNow(timestamp: number) {
+    vi.spyOn(Date, "now").mockReturnValue(timestamp);
+  }
+
+  it("returns 'context_overflow' when token usage is high (>= 80%)", () => {
+    const ctx: ResetReasonContext = {
+      totalTokens: 85000,
+      contextTokens: 100000,
+    };
+    expect(inferResetReason(ctx)).toBe("context_overflow");
+  });
+
+  it("returns 'context_overflow' when percentUsed is >= 80", () => {
+    const ctx: ResetReasonContext = {
+      percentUsed: 82,
+    };
+    expect(inferResetReason(ctx)).toBe("context_overflow");
+  });
+
+  it("returns 'daily' when date has changed and token usage is low", () => {
+    // Reset detected at 4:05 AM — typical daily reset
+    const resetAt = new Date("2026-03-06T04:05:00+09:00").getTime();
+    const lastActiveAt = new Date("2026-03-05T23:30:00+09:00").getTime();
+    mockNow(resetAt);
+
+    const ctx: ResetReasonContext = {
+      totalTokens: 5000,
+      contextTokens: 100000,
+      lastActiveAt,
+    };
+    expect(inferResetReason(ctx)).toBe("daily");
+  });
+
+  it("returns 'idle' when last activity was > 6 hours ago and token usage is low", () => {
+    const now = new Date("2026-03-06T15:00:00+09:00").getTime();
+    const lastActiveAt = new Date("2026-03-06T02:00:00+09:00").getTime(); // 13h ago
+    mockNow(now);
+
+    const ctx: ResetReasonContext = {
+      totalTokens: 3000,
+      contextTokens: 100000,
+      lastActiveAt,
+    };
+    expect(inferResetReason(ctx)).toBe("idle");
+  });
+
+  it("returns 'manual' when isManual flag is set", () => {
+    const ctx: ResetReasonContext = {
+      isManual: true,
+    };
+    expect(inferResetReason(ctx)).toBe("manual");
+  });
+
+  it("prefers gateway-provided reason over inference", () => {
+    const ctx: ResetReasonContext = {
+      gatewayReason: "daily",
+      totalTokens: 95000,
+      contextTokens: 100000, // would infer context_overflow
+    };
+    expect(inferResetReason(ctx)).toBe("daily");
+  });
+
+  it("returns 'unknown' when no heuristic matches", () => {
+    const ctx: ResetReasonContext = {};
+    expect(inferResetReason(ctx)).toBe("unknown");
+  });
+
+  it("handles edge case: exactly 80% usage → context_overflow", () => {
+    const ctx: ResetReasonContext = {
+      totalTokens: 80000,
+      contextTokens: 100000,
+    };
+    expect(inferResetReason(ctx)).toBe("context_overflow");
+  });
+
+  it("handles edge case: 79% usage → not context_overflow", () => {
+    const now = new Date("2026-03-06T15:00:00+09:00").getTime();
+    mockNow(now);
+    const ctx: ResetReasonContext = {
+      totalTokens: 79000,
+      contextTokens: 100000,
+      lastActiveAt: now - 1000, // just active
+    };
+    expect(inferResetReason(ctx)).not.toBe("context_overflow");
+  });
+
+  it("returns 'daily' for same-day reset at daily reset hour (4 AM)", () => {
+    // Reset at 4:01 AM, last active at 3:55 AM same day — still daily
+    const resetAt = new Date("2026-03-06T04:01:00+09:00").getTime();
+    const lastActiveAt = new Date("2026-03-06T03:55:00+09:00").getTime();
+    mockNow(resetAt);
+
+    const ctx: ResetReasonContext = {
+      totalTokens: 2000,
+      contextTokens: 100000,
+      lastActiveAt,
+      dailyResetHour: 4,
+    };
+    expect(inferResetReason(ctx)).toBe("daily");
+  });
+});
+
+describe("resetReasonLabel", () => {
+  it("returns correct Korean label for context_overflow", () => {
+    const label = resetReasonLabel("context_overflow");
+    expect(label.icon).toBe("🔄");
+    expect(label.text).toContain("컨텍스트");
+  });
+
+  it("returns correct Korean label for daily", () => {
+    const label = resetReasonLabel("daily");
+    expect(label.icon).toBe("🌅");
+    expect(label.text).toContain("하루");
+  });
+
+  it("returns correct Korean label for idle", () => {
+    const label = resetReasonLabel("idle");
+    expect(label.icon).toBe("💤");
+    expect(label.text).toContain("미활동");
+  });
+
+  it("returns correct Korean label for manual", () => {
+    const label = resetReasonLabel("manual");
+    expect(label.icon).toBe("🔄");
+    expect(label.text).toContain("새 세션");
+  });
+
+  it("returns fallback label for unknown", () => {
+    const label = resetReasonLabel("unknown");
+    expect(label.icon).toBe("🔄");
+    expect(label.text).toContain("세션 갱신");
+  });
+
+  it("accepts all ResetReason values without throwing", () => {
+    const reasons: ResetReason[] = [
+      "context_overflow", "daily", "idle", "manual", "unknown",
+    ];
+    for (const r of reasons) {
+      expect(() => resetReasonLabel(r)).not.toThrow();
+    }
+  });
+});

--- a/apps/web/src/components/chat/message-list.tsx
+++ b/apps/web/src/components/chat/message-list.tsx
@@ -13,6 +13,7 @@ import { AgentAvatar } from "@/components/ui/agent-avatar";
 
 import { blobDownload, forceDownloadUrl } from "@/lib/utils/download";
 import { formatTime } from "@/lib/utils/format-time";
+import { resetReasonLabel, type ResetReason } from "@/lib/gateway/reset-reason";
 
 /** Get file extension from filename */
 export function getExt(name: string): string {
@@ -492,6 +493,7 @@ export function MessageList({
               return (
                 <SessionBoundary
                   key={msg.id}
+                  reason={msg.resetReason}
                   onLoadContext={onLoadPreviousContext}
                   onViewHistory={onOpenTopicHistory}
                 />
@@ -537,12 +539,15 @@ export function MessageList({
 }
 
 function SessionBoundary({
+  reason,
   onLoadContext,
   onViewHistory,
 }: {
+  reason?: string;
   onLoadContext?: () => void | Promise<void>;
   onViewHistory?: () => void;
 }) {
+  const label = resetReasonLabel((reason || "unknown") as ResetReason);
   const [bridgeSent, setBridgeSent] = useState(false);
   const [sending, setSending] = useState(false);
 
@@ -564,8 +569,8 @@ function SessionBoundary({
       <div className="flex-1 border-t border-dashed border-amber-600/40" />
       <div className="flex flex-col items-center gap-2">
         <div className="flex items-center gap-1.5 text-[11px] font-medium text-amber-500/80">
-          <RefreshCw size={12} />
-          <span>세션 갱신됨 (컨텍스트 한도 도달)</span>
+          <span>{label.icon}</span>
+          <span>{label.text}</span>
         </div>
         <div className="flex items-center gap-2">
           {onLoadContext && (

--- a/apps/web/src/lib/gateway/hooks.tsx
+++ b/apps/web/src/lib/gateway/hooks.tsx
@@ -40,6 +40,7 @@ import {
   type GatewayConfig,
 } from "@intelli-claw/shared";
 
+import { inferResetReason } from "./reset-reason";
 import {
   trackSessionId,
   markSessionEnded,
@@ -134,9 +135,22 @@ export function useSessions() {
           console.log(`[AWF] Session reset detected: ${key} ${oldSessionId.slice(0, 8)} → ${newSessionId.slice(0, 8)}`);
           const label = s.label ? String(s.label) : undefined;
           const totalTokens = typeof s.totalTokens === "number" ? s.totalTokens : undefined;
+          const contextTokens = typeof s.contextTokens === "number" ? s.contextTokens : undefined;
+          const percentUsed = typeof s.percentUsed === "number" ? s.percentUsed : undefined;
+          const gatewayReason = typeof s.resetReason === "string" ? s.resetReason : undefined;
+          const lastActiveAt = typeof s.updatedAt === "number" ? s.updatedAt : undefined;
+
+          const reason = inferResetReason({
+            totalTokens,
+            contextTokens,
+            percentUsed,
+            gatewayReason: gatewayReason as any,
+            lastActiveAt,
+          });
+
           markSessionEnded(key, oldSessionId, { totalTokens }).catch(() => {});
           trackSessionId(key, newSessionId, { label }).catch(() => {});
-          emitSessionReset({ key, oldSessionId, newSessionId });
+          emitSessionReset({ key, oldSessionId, newSessionId, reason });
         } else if (!oldSessionId) {
           const existing = await getCurrentSessionId(key);
           if (!existing || existing !== newSessionId) {
@@ -371,6 +385,8 @@ export interface DisplayMessage {
   attachments?: DisplayAttachment[];
   oldSessionId?: string;
   newSessionId?: string;
+  /** #156: Why the session was reset */
+  resetReason?: string;
   replyTo?: ReplyTo;
 }
 
@@ -943,6 +959,7 @@ export function useChat(sessionKey?: string) {
             oldSessionId: lm.oldSessionId,
             newSessionId: lm.newSessionId,
             replyTo: lm.replyTo as ReplyTo | undefined,
+            resetReason: lm.resetReason,
           });
 
           // Local messages not in gateway — split into older (prepend) and newer (append)
@@ -1864,11 +1881,12 @@ export function useChat(sessionKey?: string) {
       if (event.key !== sessionKeyRef.current) return;
       console.log(`[AWF] Session reset for current chat: ${event.key}`);
 
-      // Boundary UI message (기존 동작 유지)
+      // Boundary UI message with reason (#156)
       const boundaryMsg: DisplayMessage = {
         id: `boundary-${event.oldSessionId.slice(0, 8)}-${Date.now()}`,
         role: "session-boundary", content: "", timestamp: new Date().toISOString(),
         toolCalls: [], oldSessionId: event.oldSessionId, newSessionId: event.newSessionId,
+        resetReason: event.reason,
       };
       setMessages((prev) => [...prev, boundaryMsg]);
       // Persist boundary to local store
@@ -1880,6 +1898,7 @@ export function useChat(sessionKey?: string) {
         timestamp: boundaryMsg.timestamp,
         oldSessionId: event.oldSessionId,
         newSessionId: event.newSessionId,
+        resetReason: event.reason,
       }]).catch(() => {});
 
       // IndexedDB에 이전 세션 요약만 저장 (auto bridge 제거 — Gateway의 session reset prompt와 중복 방지)

--- a/apps/web/src/lib/gateway/message-store.ts
+++ b/apps/web/src/lib/gateway/message-store.ts
@@ -28,6 +28,8 @@ export interface StoredMessage {
   oldSessionId?: string;
   newSessionId?: string;
   replyTo?: ReplyToData;
+  /** #156: Why the session was reset */
+  resetReason?: string;
 }
 
 // --- IndexedDB helpers ---

--- a/apps/web/src/lib/gateway/reset-reason.ts
+++ b/apps/web/src/lib/gateway/reset-reason.ts
@@ -1,0 +1,141 @@
+/**
+ * Session reset reason inference (#156)
+ *
+ * Since the OpenClaw Gateway does not yet provide a `resetReason` field
+ * in `sessions.list`, we infer the reason from available context:
+ *
+ * - Token usage ratio → context_overflow
+ * - Time of day + date change → daily reset
+ * - Long inactivity → idle reset
+ * - Explicit user action → manual
+ *
+ * When Gateway eventually adds `resetReason`, it takes precedence
+ * via the `gatewayReason` field (future-proof).
+ */
+
+export type ResetReason =
+  | "context_overflow"
+  | "daily"
+  | "idle"
+  | "manual"
+  | "unknown";
+
+export interface ResetReasonContext {
+  /** Token count at time of reset (old session's final state) */
+  totalTokens?: number;
+  /** Context window size for the model */
+  contextTokens?: number;
+  /** Pre-computed percent used (0-100) */
+  percentUsed?: number;
+  /** Timestamp of last user activity before reset */
+  lastActiveAt?: number;
+  /** Whether the user triggered this reset manually (/new, /reset) */
+  isManual?: boolean;
+  /** Gateway-provided reason (future-proof — takes precedence if present) */
+  gatewayReason?: ResetReason;
+  /** Configured daily reset hour (default: 4) */
+  dailyResetHour?: number;
+}
+
+/** Threshold: token usage >= this % is considered context overflow */
+const CONTEXT_OVERFLOW_THRESHOLD = 0.80;
+
+/** Threshold: inactivity >= this duration (ms) is considered idle reset */
+const IDLE_THRESHOLD_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+/**
+ * Infer the reason a session was reset from available context.
+ *
+ * Priority:
+ * 1. Gateway-provided reason (future-proof)
+ * 2. Manual flag
+ * 3. Context overflow (token usage >= 80%)
+ * 4. Daily reset (near daily reset hour, date changed or low usage)
+ * 5. Idle reset (long inactivity)
+ * 6. Unknown
+ */
+export function inferResetReason(ctx: ResetReasonContext): ResetReason {
+  // 1. Gateway-provided reason always wins
+  if (ctx.gatewayReason) {
+    return ctx.gatewayReason;
+  }
+
+  // 2. Manual
+  if (ctx.isManual) {
+    return "manual";
+  }
+
+  // 3. Context overflow
+  const usageRatio = computeUsageRatio(ctx);
+  if (usageRatio !== null && usageRatio >= CONTEXT_OVERFLOW_THRESHOLD) {
+    return "context_overflow";
+  }
+
+  // 4. Daily reset — check if we're near the daily reset hour
+  const dailyHour = ctx.dailyResetHour ?? 4;
+  const now = Date.now();
+  const nowDate = new Date(now);
+  const currentHour = nowDate.getHours();
+
+  // Within ±1 hour of daily reset hour and token usage is low
+  const nearDailyHour = Math.abs(currentHour - dailyHour) <= 1 ||
+    (dailyHour === 0 && currentHour === 23) ||
+    (dailyHour === 23 && currentHour === 0);
+
+  if (nearDailyHour && (usageRatio === null || usageRatio < CONTEXT_OVERFLOW_THRESHOLD)) {
+    return "daily";
+  }
+
+  // Also daily if date changed (last active on different day) and usage is low
+  if (ctx.lastActiveAt) {
+    const lastDate = new Date(ctx.lastActiveAt);
+    const dateChanged =
+      lastDate.getFullYear() !== nowDate.getFullYear() ||
+      lastDate.getMonth() !== nowDate.getMonth() ||
+      lastDate.getDate() !== nowDate.getDate();
+
+    if (dateChanged && (usageRatio === null || usageRatio < CONTEXT_OVERFLOW_THRESHOLD)) {
+      return "daily";
+    }
+  }
+
+  // 5. Idle reset — long inactivity
+  if (ctx.lastActiveAt) {
+    const idleDuration = now - ctx.lastActiveAt;
+    if (idleDuration >= IDLE_THRESHOLD_MS) {
+      return "idle";
+    }
+  }
+
+  // 6. Unknown
+  return "unknown";
+}
+
+function computeUsageRatio(ctx: ResetReasonContext): number | null {
+  if (ctx.percentUsed != null) {
+    return ctx.percentUsed / 100;
+  }
+  if (ctx.totalTokens != null && ctx.contextTokens != null && ctx.contextTokens > 0) {
+    return ctx.totalTokens / ctx.contextTokens;
+  }
+  return null;
+}
+
+// ---- UI Labels ----
+
+export interface ResetReasonLabel {
+  icon: string;
+  text: string;
+}
+
+const LABELS: Record<ResetReason, ResetReasonLabel> = {
+  context_overflow: { icon: "🔄", text: "세션 갱신됨 (컨텍스트 한도 도달)" },
+  daily:           { icon: "🌅", text: "새로운 하루, 새 세션이 시작되었습니다" },
+  idle:            { icon: "💤", text: "장시간 미활동으로 세션이 초기화되었습니다" },
+  manual:          { icon: "🔄", text: "새 세션이 시작되었습니다" },
+  unknown:         { icon: "🔄", text: "세션 갱신됨" },
+};
+
+export function resetReasonLabel(reason: ResetReason): ResetReasonLabel {
+  return LABELS[reason] || LABELS.unknown;
+}

--- a/packages/shared/src/hooks/use-gateway.tsx
+++ b/packages/shared/src/hooks/use-gateway.tsx
@@ -145,6 +145,8 @@ export interface SessionResetEvent {
   key: string;
   oldSessionId: string;
   newSessionId: string;
+  /** Why the session was reset (inferred or gateway-provided) */
+  reason?: string;
 }
 
 type SessionResetListener = (event: SessionResetEvent) => void;


### PR DESCRIPTION
Closes #156

## Root Cause
- `SessionResetEvent`에 `reason` 필드 없음
- `SessionBoundary` 컴포넌트 문구 하드코딩 ("컨텍스트 한도 도달")
- Gateway `sessions.list`에 `resetReason` 미제공

## Changes (7 files, +370/-6)

### 핵심: 리셋 사유 추론 엔진 (`reset-reason.ts`)
Gateway가 reason을 아직 제공하지 않으므로, 사용 가능한 컨텍스트로 정밀 추론:

| 우선순위 | 조건 | 판정 |
|----------|------|------|
| 1 | Gateway `resetReason` 필드 존재 (향후) | 그대로 사용 |
| 2 | `isManual` 플래그 | `manual` |
| 3 | 토큰 사용량 ≥ 80% | `context_overflow` |
| 4 | 일일 리셋 시간대 (±1h) + 낮은 사용량 | `daily` |
| 5 | 6시간+ 미활동 | `idle` |
| 6 | 기타 | `unknown` |

### 사유별 UI
| 사유 | 표시 |
|------|------|
| `context_overflow` | 🔄 세션 갱신됨 (컨텍스트 한도 도달) |
| `daily` | 🌅 새로운 하루, 새 세션이 시작되었습니다 |
| `idle` | 💤 장시간 미활동으로 세션이 초기화되었습니다 |
| `manual` | 🔄 새 세션이 시작되었습니다 |
| `unknown` | 🔄 세션 갱신됨 |

### 추가 수정 (이슈에서 놓친 부분)
- `StoredMessage.resetReason` → IndexedDB에 사유 영구 저장 (새로고침 후에도 유지)
- `toDisplayMsg()` 매핑에 `resetReason` 포함 → 로컬 복원 시 사유 보존
- Gateway가 향후 `resetReason` 제공 시 자동 전환 (future-proof)

## Tests
- 추론 로직 16건 신규 + UI 렌더링 5건 확장
- 전체 902건 통과, Vite 빌드 정상