### PR TITLE
fix(#154): AI 응답이 '생각 중' 상태에서 멈추는 현상 해결

### DIFF
--- a/apps/web/src/__tests__/issue-154-streaming-stuck.test.ts
+++ b/apps/web/src/__tests__/issue-154-streaming-stuck.test.ts
@@ -1,0 +1,391 @@
+/**
+ * issue-154-streaming-stuck.test.ts
+ *
+ * Tests for #154: AI response stuck in "thinking" state.
+ *
+ * Root causes addressed:
+ * 1. WebSocket stale connection detection (client heartbeat)
+ * 2. Tiered streaming timeout (thinking vs writing phases)
+ * 3. lifecycle.end without sessionKey should still match by runId
+ * 4. flushDeferredHistoryReload must guarantee at least one reload
+ * 5. Reconnect safety timer should await loadHistory completion
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import React from "react";
+import { createMockClient, type MockClient } from "./helpers/mock-gateway-client";
+import { installMockStorage } from "./helpers/mock-storage";
+import {
+  makeAgentEvent,
+  makeStreamChunk,
+  makeLifecycleStart,
+  makeLifecycleEnd,
+  makeReconnectEvent,
+  makeEventFrame,
+  resetFixtureCounter,
+} from "./helpers/fixtures";
+
+// --- Mocks ---
+
+let mockClient: MockClient | null = null;
+let mockState = "connected";
+
+vi.mock("@intelli-claw/shared", async () => {
+  const actual = await vi.importActual<typeof import("@intelli-claw/shared")>("@intelli-claw/shared");
+  return {
+    ...actual,
+    useGateway: () => ({
+      client: mockClient,
+      state: mockState,
+      error: null,
+      updateConfig: vi.fn(),
+      mainSessionKey: mockClient?.mainSessionKey || "",
+      serverVersion: "",
+      serverCommit: "",
+      gatewayUrl: "",
+    }),
+    GatewayProvider: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock("@/lib/gateway/message-store", () => ({
+  saveMessages: vi.fn().mockResolvedValue(undefined),
+  getLocalMessages: vi.fn().mockResolvedValue([]),
+  backfillFromApi: vi.fn().mockResolvedValue([]),
+  isBackfillDone: vi.fn().mockReturnValue(true),
+  runMessageStoreMigration: vi.fn(),
+}));
+
+vi.mock("@/lib/gateway/topic-store", () => ({
+  trackSessionId: vi.fn().mockResolvedValue(undefined),
+  markSessionEnded: vi.fn().mockResolvedValue(undefined),
+  getCurrentSessionId: vi.fn().mockResolvedValue(null),
+  getTopicHistory: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/platform/media-path", () => ({
+  validateMediaPath: vi.fn().mockReturnValue({ valid: true }),
+  sanitizeAttachmentPath: vi.fn((p: string) => p),
+}));
+
+vi.mock("@/lib/platform", () => ({
+  platform: { mediaUrl: (p: string) => `/media/${p}` },
+}));
+
+vi.mock("@/lib/mime-types", () => ({
+  getMimeType: (ext: string) => {
+    const map: Record<string, string> = { png: "image/png", jpg: "image/jpeg" };
+    return map[ext] || "application/octet-stream";
+  },
+}));
+
+import { useChat } from "@/lib/gateway/hooks";
+
+let storageCleanup: () => void;
+
+beforeEach(() => {
+  resetFixtureCounter();
+  vi.useFakeTimers();
+  const storage = installMockStorage();
+  storageCleanup = storage.cleanup;
+  mockClient = createMockClient("test:agent");
+  mockState = "connected";
+  mockClient.request.mockResolvedValue({ messages: [] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  storageCleanup();
+  vi.restoreAllMocks();
+});
+
+// ===================================================================
+// 1. lifecycle.end without sessionKey — should match by runId (#154)
+// ===================================================================
+
+describe("#154 — lifecycle.end without sessionKey", () => {
+  it("should finalize stream when lifecycle.end has runId but no sessionKey", async () => {
+    const { result } = renderHook(() => useChat("test:agent"));
+    await act(async () => { vi.advanceTimersByTime(100); });
+
+    // lifecycle.start WITH sessionKey
+    act(() => {
+      mockClient!.emitEvent(makeLifecycleStart("test:agent", "run-abc"));
+    });
+    expect(result.current.streaming).toBe(true);
+    expect(result.current.agentStatus.phase).toBe("thinking");
+
+    // Stream some content
+    act(() => {
+      mockClient!.emitEvent(makeStreamChunk("Hello", "test:agent"));
+    });
+    await act(async () => { vi.advanceTimersByTime(20); });
+
+    // lifecycle.end WITHOUT sessionKey but WITH matching runId
+    act(() => {
+      mockClient!.emitEvent(makeAgentEvent(
+        "lifecycle",
+        { phase: "end", runId: "run-abc" },
+        // No sessionKey in the payload
+      ));
+    });
+
+    // Should still finalize
+    expect(result.current.streaming).toBe(false);
+    expect(result.current.agentStatus.phase).toBe("idle");
+  });
+
+  it("should NOT finalize when lifecycle.end has wrong runId and no sessionKey", async () => {
+    const { result } = renderHook(() => useChat("test:agent"));
+    await act(async () => { vi.advanceTimersByTime(100); });
+
+    act(() => {
+      mockClient!.emitEvent(makeLifecycleStart("test:agent", "run-abc"));
+    });
+
+    act(() => {
+      mockClient!.emitEvent(makeStreamChunk("Hello", "test:agent"));
+    });
+    await act(async () => { vi.advanceTimersByTime(20); });
+
+    // lifecycle.end with WRONG runId and no sessionKey
+    act(() => {
+      mockClient!.emitEvent(makeAgentEvent(
+        "lifecycle",
+        { phase: "end", runId: "run-DIFFERENT" },
+      ));
+    });
+
+    // Should still be streaming (wrong runId should not finalize)
+    expect(result.current.streaming).toBe(true);
+  });
+});
+
+// ===================================================================
+// 2. Streaming timeout — thinking phase should have shorter timeout
+// ===================================================================
+
+describe("#154 — tiered streaming timeout", () => {
+  it("should timeout faster during thinking phase (no content received)", async () => {
+    const { result } = renderHook(() => useChat("test:agent"));
+    await act(async () => { vi.advanceTimersByTime(100); });
+
+    // lifecycle.start — enters thinking phase
+    act(() => {
+      mockClient!.emitEvent(makeLifecycleStart("test:agent", "run-1"));
+    });
+    expect(result.current.streaming).toBe(true);
+    expect(result.current.agentStatus.phase).toBe("thinking");
+
+    // Advance to 45 seconds — should timeout during thinking
+    await act(async () => { vi.advanceTimersByTime(45_000); });
+
+    expect(result.current.streaming).toBe(false);
+    expect(result.current.agentStatus.phase).toBe("idle");
+  });
+
+  it("should have longer timeout once writing starts", async () => {
+    const { result } = renderHook(() => useChat("test:agent"));
+    await act(async () => { vi.advanceTimersByTime(100); });
+
+    act(() => {
+      mockClient!.emitEvent(makeLifecycleStart("test:agent", "run-1"));
+    });
+
+    // Stream some content — transitions to writing phase
+    act(() => {
+      mockClient!.emitEvent(makeStreamChunk("Starting response...", "test:agent"));
+    });
+    await act(async () => { vi.advanceTimersByTime(20); });
+
+    expect(result.current.agentStatus.phase).toBe("writing");
+
+    // At 45 seconds — should NOT have timed out because writing timeout is longer
+    await act(async () => { vi.advanceTimersByTime(44_980); });
+    expect(result.current.streaming).toBe(true);
+
+    // At 90 seconds — should timeout
+    await act(async () => { vi.advanceTimersByTime(45_000); });
+    expect(result.current.streaming).toBe(false);
+  });
+});
+
+// ===================================================================
+// 3. flushDeferredHistoryReload — guaranteed reload after finalize
+// ===================================================================
+
+describe("#154 — flushDeferredHistoryReload guarantee", () => {
+  it("should reload history even if lastLoadAt was recent", async () => {
+    const { result } = renderHook(() => useChat("test:agent"));
+    await act(async () => { vi.advanceTimersByTime(100); });
+
+    // Count loadHistory calls (via chat.history requests)
+    const initialCallCount = mockClient!.request.mock.calls.filter(
+      (c: unknown[]) => c[0] === "chat.history"
+    ).length;
+
+    // Start and complete a lifecycle
+    act(() => {
+      mockClient!.emitEvent(makeLifecycleStart("test:agent", "run-1"));
+    });
+    act(() => {
+      mockClient!.emitEvent(makeStreamChunk("Response", "test:agent"));
+    });
+    await act(async () => { vi.advanceTimersByTime(20); });
+
+    // lifecycle.end should trigger history reload regardless of throttle
+    act(() => {
+      mockClient!.emitEvent(makeLifecycleEnd("test:agent", "run-1"));
+    });
+    await act(async () => { vi.advanceTimersByTime(100); });
+
+    const finalCallCount = mockClient!.request.mock.calls.filter(
+      (c: unknown[]) => c[0] === "chat.history"
+    ).length;
+
+    // Should have at least 1 more chat.history call after finalize
+    expect(finalCallCount).toBeGreaterThan(initialCallCount);
+  });
+});
+
+// ===================================================================
+// 4. Reconnect safety timer — should wait for loadHistory
+// ===================================================================
+
+describe("#154 — reconnect with streaming state", () => {
+  it("should clear streaming state after reconnect when no new events arrive", async () => {
+    const { result } = renderHook(() => useChat("test:agent"));
+    await act(async () => { vi.advanceTimersByTime(100); });
+
+    // Start streaming
+    act(() => {
+      mockClient!.emitEvent(makeLifecycleStart("test:agent", "run-1"));
+    });
+    act(() => {
+      mockClient!.emitEvent(makeStreamChunk("Partial...", "test:agent"));
+    });
+    await act(async () => { vi.advanceTimersByTime(20); });
+    expect(result.current.streaming).toBe(true);
+
+    // Simulate reconnect
+    act(() => {
+      mockClient!.emitEvent(makeReconnectEvent());
+    });
+
+    // Wait for reconnect safety timer
+    await act(async () => { vi.advanceTimersByTime(5_000); });
+
+    // Streaming should be cleared
+    expect(result.current.streaming).toBe(false);
+    expect(result.current.agentStatus.phase).toBe("idle");
+  });
+
+  it("should cancel reconnect safety timer if new lifecycle.start arrives", async () => {
+    const { result } = renderHook(() => useChat("test:agent"));
+    await act(async () => { vi.advanceTimersByTime(100); });
+
+    // Start streaming
+    act(() => {
+      mockClient!.emitEvent(makeLifecycleStart("test:agent", "run-1"));
+    });
+    act(() => {
+      mockClient!.emitEvent(makeStreamChunk("Partial...", "test:agent"));
+    });
+    await act(async () => { vi.advanceTimersByTime(20); });
+
+    // Reconnect
+    act(() => {
+      mockClient!.emitEvent(makeReconnectEvent());
+    });
+
+    // New lifecycle starts before safety timer fires
+    await act(async () => { vi.advanceTimersByTime(1_000); });
+    act(() => {
+      mockClient!.emitEvent(makeLifecycleStart("test:agent", "run-2"));
+    });
+
+    // Wait past the original safety timer window
+    await act(async () => { vi.advanceTimersByTime(5_000); });
+
+    // Should still be streaming (new run is active)
+    expect(result.current.streaming).toBe(true);
+  });
+
+  it("should cancel reconnect safety timer if text delta arrives", async () => {
+    const { result } = renderHook(() => useChat("test:agent"));
+    await act(async () => { vi.advanceTimersByTime(100); });
+
+    act(() => {
+      mockClient!.emitEvent(makeLifecycleStart("test:agent", "run-1"));
+    });
+    act(() => {
+      mockClient!.emitEvent(makeStreamChunk("Start...", "test:agent"));
+    });
+    await act(async () => { vi.advanceTimersByTime(20); });
+
+    // Reconnect
+    act(() => {
+      mockClient!.emitEvent(makeReconnectEvent());
+    });
+
+    // Text delta arrives before safety timer
+    await act(async () => { vi.advanceTimersByTime(1_500); });
+    act(() => {
+      mockClient!.emitEvent(makeStreamChunk(" more text", "test:agent"));
+    });
+    await act(async () => { vi.advanceTimersByTime(20); });
+
+    // Wait past the safety timer window
+    await act(async () => { vi.advanceTimersByTime(5_000); });
+
+    // Should still be streaming (events resumed)
+    expect(result.current.streaming).toBe(true);
+  });
+});
+
+// ===================================================================
+// 5. Client heartbeat — stale connection detection
+// ===================================================================
+
+describe("#154 — client heartbeat (stale connection detection)", () => {
+  it("GatewayClient should detect stale connections via heartbeat", async () => {
+    // This tests that the GatewayClient class implements heartbeat.
+    // Import the real class (not the mock).
+    const { GatewayClient } = await import("@intelli-claw/shared");
+
+    // Verify the class has heartbeat-related configuration
+    // The actual WebSocket connection can't be tested in unit tests,
+    // so we verify the class structure supports heartbeat.
+    const client = new GatewayClient("ws://localhost:1234", "test-token");
+    expect(client).toBeDefined();
+
+    // Clean up
+    client.disconnect();
+  });
+});
+
+// ===================================================================
+// 6. Disconnect during thinking — agentStatus transitions
+// ===================================================================
+
+describe("#154 — disconnect during thinking phase", () => {
+  it("should set agentStatus to waiting when disconnected during streaming", async () => {
+    const { result, rerender } = renderHook(() => useChat("test:agent"));
+    await act(async () => { vi.advanceTimersByTime(100); });
+
+    // Start streaming
+    act(() => {
+      mockClient!.emitEvent(makeLifecycleStart("test:agent", "run-1"));
+    });
+    expect(result.current.agentStatus.phase).toBe("thinking");
+
+    // Simulate disconnection
+    act(() => {
+      mockState = "disconnected";
+    });
+    rerender();
+    await act(async () => { vi.advanceTimersByTime(100); });
+
+    expect(result.current.agentStatus.phase).toBe("waiting");
+  });
+});

--- a/apps/web/src/lib/gateway/hooks.tsx
+++ b/apps/web/src/lib/gateway/hooks.tsx
@@ -555,7 +555,11 @@ export function useChat(sessionKey?: string) {
     })()
   );
 
-  const STREAMING_TIMEOUT_MS = 120_000;
+  // Tiered streaming timeouts (#154):
+  // - Thinking phase (no content yet): 45s — stale connections are detected faster
+  // - Writing phase (content streaming): 90s — allows long responses to complete
+  const THINKING_TIMEOUT_MS = 45_000;
+  const WRITING_TIMEOUT_MS = 90_000;
   const queueStorageKey = sessionKey ? `awf:queue:${sessionKey}` : null;
   const pendingStreamStorageKey = sessionKey ? `${PENDING_STREAM_SESSION_KEY_PREFIX}${sessionKey}` : null;
 
@@ -592,10 +596,12 @@ export function useChat(sessionKey?: string) {
     }
   }, []);
 
-  const startStreamingTimeout = useCallback(() => {
+  const startStreamingTimeout = useCallback((phase?: "thinking" | "writing") => {
     clearStreamingTimeout();
+    // Use shorter timeout for thinking phase, longer for writing (#154)
+    const timeoutMs = phase === "writing" ? WRITING_TIMEOUT_MS : THINKING_TIMEOUT_MS;
     streamingTimeoutRef.current = setTimeout(() => {
-      console.warn("[AWF] streaming timeout — force reset");
+      console.warn(`[AWF] streaming timeout (${phase || "thinking"}, ${timeoutMs}ms) — force reset`);
       if (streamBuf.current) {
         const id = streamBuf.current.id;
         setMessages((prev) =>
@@ -607,7 +613,7 @@ export function useChat(sessionKey?: string) {
       clearPersistedPendingStream();
       setStreaming(false);
       setAgentStatusDebug({ phase: "idle" });
-    }, STREAMING_TIMEOUT_MS);
+    }, timeoutMs);
   }, [clearStreamingTimeout, clearPersistedPendingStream]);
 
   useEffect(() => {
@@ -703,7 +709,7 @@ export function useChat(sessionKey?: string) {
         });
       }
       restoredFromSnapshotRef.current = true;
-      startStreamingTimeout();
+      startStreamingTimeout(parsed.content ? "writing" : "thinking");
       console.log("[AWF] Restored pending stream from sessionStorage", {
         runId: parsed.runId?.slice(0, 8),
         streamId: parsed.streamId,
@@ -1081,9 +1087,11 @@ export function useChat(sessionKey?: string) {
   const flushDeferredHistoryReload = useCallback(() => {
     if (!pendingHistoryReloadRef.current) return;
     pendingHistoryReloadRef.current = false;
-    if (Date.now() - lastLoadAtRef.current >= 800) {
-      loadHistory();
-    }
+    // Always reload after a run completes (#154).
+    // The previous 800ms throttle could skip the reload when loadHistory was
+    // called recently (e.g., during reconnect), leaving the final response
+    // invisible until the next user interaction.
+    loadHistory();
   }, [loadHistory]);
 
   useEffect(() => { loadHistory(); }, [loadHistory]);
@@ -1305,12 +1313,22 @@ export function useChat(sessionKey?: string) {
 
       // Strict session isolation (#5536-v2):
       // 1) If event has a sessionKey, it MUST match our bound session key
-      // 2) If event has NO sessionKey, reject it when we have a session
-      // 3) Double-check against both the closure value AND the ref to catch
-      //    any edge case where one drifts from the other
+      // 2) If event has NO sessionKey, reject it when we have a session —
+      //    UNLESS it's a lifecycle event whose runId matches our active run (#154).
+      //    Gateway may omit sessionKey on lifecycle.end while including it on
+      //    lifecycle.start, causing the end event to be silently dropped.
       if (evSessionKey && evSessionKey !== boundSessionKey) return;
       if (evSessionKey && evSessionKey !== sessionKeyRef.current) return;
-      if (!evSessionKey && (boundSessionKey || sessionKeyRef.current)) return;
+      if (!evSessionKey && (boundSessionKey || sessionKeyRef.current)) {
+        // Allow lifecycle events through if they carry a runId matching our active run
+        const eventRunId = (raw.runId ?? data?.runId) as string | undefined;
+        const isMatchingLifecycle =
+          stream === "lifecycle" &&
+          eventRunId &&
+          runIdRef.current &&
+          eventRunId === runIdRef.current;
+        if (!isMatchingLifecycle) return;
+      }
 
 
       // Ignore events after abort until next lifecycle start
@@ -1321,7 +1339,7 @@ export function useChat(sessionKey?: string) {
         // Cancel reconnect safety timer — events are flowing again
         if (reconnectSafetyRef.current) { clearTimeout(reconnectSafetyRef.current); reconnectSafetyRef.current = null; }
         setStreaming(true);
-        startStreamingTimeout();
+        startStreamingTimeout("writing");
         setAgentStatusDebug({ phase: "writing" });
         if (!streamBuf.current) {
           streamBuf.current = { id: `stream-${Date.now()}-${++streamIdCounter.current}`, content: "", toolCalls: new Map() };
@@ -1466,7 +1484,7 @@ export function useChat(sessionKey?: string) {
         if (reconnectSafetyRef.current) { clearTimeout(reconnectSafetyRef.current); reconnectSafetyRef.current = null; }
         setStreaming(true);
         abortedRef.current = false;
-        startStreamingTimeout();
+        startStreamingTimeout("thinking");
         runIdRef.current = resolveRunId(raw, data);
         const runKey = finalEventKey(runIdRef.current);
         if (runKey) {
@@ -1547,7 +1565,7 @@ export function useChat(sessionKey?: string) {
       if (!client || state !== "connected") return;
       setMessages((prev) => prev.map((m) => (m.id === msgId ? { ...m, queued: false } : m)));
       setStreaming(true);
-      startStreamingTimeout();
+      startStreamingTimeout("thinking");
       setAgentStatusDebug({ phase: "thinking" });
 
       const idempotencyKey = `awf-${Date.now()}-${Math.random().toString(36).slice(2)}`;

--- a/packages/shared/src/gateway/client.ts
+++ b/packages/shared/src/gateway/client.ts
@@ -278,8 +278,11 @@ export class GatewayClient {
       this.lastError = null;
       this.wasConnected = true;
       this.setState("connected");
-      // Ping disabled — gateway doesn't support app-level ping frames
-      // this.startPing();
+      // Enable heartbeat to detect stale connections (#154).
+      // Even if the gateway ignores the ping frame, sending data over a stale
+      // WebSocket triggers the browser's TCP stack to detect the broken pipe.
+      // If no data arrives within PONG_TIMEOUT after a ping, we close and reconnect.
+      this.startPing();
 
       // Emit synthetic reconnect event so UI can reload history
       if (isReconnect) {


### PR DESCRIPTION
## 문제
AI 응답이 "생각 중" 상태에서 멈추고, 사용자가 새 메시지를 입력해야 이전 응답이 밀려서 나타나는 현상.

## 근본 원인 분석

### 1. WebSocket 스테일 연결 미감지
- `GatewayClient.startPing()`이 주석 처리되어 **heartbeat가 비활성화** 상태
- 네트워크 무음 단절 시 브라우저가 연결 상태를 인지하지 못함
- 사용자가 새 메시지를 보낼 때 `ws.send()`가 비로소 단절을 감지

### 2. 스트리밍 타임아웃 과도 (120초)
- 연결이 끊어져도 최대 2분간 "생각 중" 상태 지속

### 3. lifecycle.end 이벤트 사일런트 드롭
- Gateway가 `lifecycle.start`에는 `sessionKey` 포함, `lifecycle.end`에는 누락 가능
- 엄격한 sessionKey 필터가 end 이벤트를 무조건 차단

### 4. flushDeferredHistoryReload 800ms 쓰로틀
- 스트림 완료 후 history 리로드가 스킵될 수 있어 응답이 화면에 미표시

## 수정 사항

| # | 수정 | 파일 |
|---|------|------|
| 1 | WebSocket heartbeat 활성화 (25초 ping + 10초 pong timeout) | `packages/shared/src/gateway/client.ts` |
| 2 | 단계별 타임아웃: thinking=45초, writing=90초 | `apps/web/src/lib/gateway/hooks.tsx` |
| 3 | lifecycle 이벤트 — sessionKey 없이 runId 매칭 허용 | `apps/web/src/lib/gateway/hooks.tsx` |
| 4 | flushDeferredHistoryReload 쓰로틀 제거 (무조건 1회 보장) | `apps/web/src/lib/gateway/hooks.tsx` |

## 테스트
- 10개 신규 테스트 (`issue-154-streaming-stuck.test.ts`)
- 전체 898 테스트 통과
- 빌드 검증 완료

Closes #154