### PR TITLE
feat(#161): 채팅 입력 히스토리 기억 — 세션별 Arrow Up/Down 탐색

### DIFF
--- a/apps/web/src/__tests__/issue-161-input-history.test.ts
+++ b/apps/web/src/__tests__/issue-161-input-history.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Issue #161 — 채팅 입력 내용 히스토리 기억 (세션별 저장)
+ *
+ * Tests cover:
+ * 1. InputHistoryStore: push, dedup, cap, session isolation, clear
+ * 2. useInputHistory hook: navigation (up/down), draft preservation, reset, session change
+ * 3. Cursor-position utilities for ArrowUp/Down integration
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import {
+  pushInput,
+  getInputHistory,
+  clearInputHistory,
+  MAX_ENTRIES_PER_SESSION,
+} from "@/lib/gateway/input-history-store";
+import { useInputHistory } from "@/hooks/use-input-history";
+
+// Fresh IndexedDB between tests (same pattern as message-store.test.ts)
+beforeEach(async () => {
+  const dbs = await indexedDB.databases();
+  for (const db of dbs) {
+    if (db.name) indexedDB.deleteDatabase(db.name);
+  }
+});
+
+// ============================================================
+// Part 1: InputHistoryStore
+// ============================================================
+
+describe("#161 — InputHistoryStore", () => {
+  it("should push and retrieve input history for a session", async () => {
+    await pushInput("agent:iclaw:main", "hello");
+    await pushInput("agent:iclaw:main", "world");
+
+    const entries = await getInputHistory("agent:iclaw:main");
+    expect(entries).toHaveLength(2);
+    expect(entries[0].text).toBe("hello");
+    expect(entries[1].text).toBe("world");
+  });
+
+  it("should skip empty/whitespace-only inputs", async () => {
+    await pushInput("agent:iclaw:main", "");
+    await pushInput("agent:iclaw:main", "   ");
+    await pushInput("agent:iclaw:main", "\n\t  ");
+
+    const entries = await getInputHistory("agent:iclaw:main");
+    expect(entries).toHaveLength(0);
+  });
+
+  it("should skip consecutive duplicate inputs", async () => {
+    await pushInput("agent:iclaw:main", "hello");
+    await pushInput("agent:iclaw:main", "hello");
+    await pushInput("agent:iclaw:main", "hello");
+
+    const entries = await getInputHistory("agent:iclaw:main");
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe("hello");
+  });
+
+  it("should allow non-consecutive duplicates", async () => {
+    await pushInput("agent:iclaw:main", "hello");
+    await pushInput("agent:iclaw:main", "world");
+    await pushInput("agent:iclaw:main", "hello");
+
+    const entries = await getInputHistory("agent:iclaw:main");
+    expect(entries).toHaveLength(3);
+  });
+
+  it("should enforce MAX_ENTRIES_PER_SESSION cap", async () => {
+    for (let i = 0; i < MAX_ENTRIES_PER_SESSION + 10; i++) {
+      await pushInput("agent:iclaw:main", `msg-${i}`);
+    }
+
+    const entries = await getInputHistory("agent:iclaw:main");
+    expect(entries).toHaveLength(MAX_ENTRIES_PER_SESSION);
+    // Should keep the newest entries
+    expect(entries[entries.length - 1].text).toBe(
+      `msg-${MAX_ENTRIES_PER_SESSION + 9}`
+    );
+    // Oldest should be trimmed
+    expect(entries[0].text).toBe(`msg-10`);
+  });
+
+  it("should isolate history between sessions", async () => {
+    await pushInput("agent:iclaw:main", "iclaw-msg");
+    await pushInput("agent:jarvis:main", "jarvis-msg");
+
+    const iclawEntries = await getInputHistory("agent:iclaw:main");
+    const jarvisEntries = await getInputHistory("agent:jarvis:main");
+
+    expect(iclawEntries).toHaveLength(1);
+    expect(iclawEntries[0].text).toBe("iclaw-msg");
+    expect(jarvisEntries).toHaveLength(1);
+    expect(jarvisEntries[0].text).toBe("jarvis-msg");
+  });
+
+  it("should clear history for a specific session only", async () => {
+    await pushInput("agent:iclaw:main", "msg1");
+    await pushInput("agent:iclaw:main", "msg2");
+    await pushInput("agent:jarvis:main", "keep-me");
+
+    await clearInputHistory("agent:iclaw:main");
+
+    const iclawEntries = await getInputHistory("agent:iclaw:main");
+    const jarvisEntries = await getInputHistory("agent:jarvis:main");
+    expect(iclawEntries).toHaveLength(0);
+    expect(jarvisEntries).toHaveLength(1);
+  });
+
+  it("should trim whitespace from stored text", async () => {
+    await pushInput("agent:iclaw:main", "  hello world  ");
+    const entries = await getInputHistory("agent:iclaw:main");
+    expect(entries[0].text).toBe("hello world");
+  });
+
+  it("should return empty for undefined/empty sessionKey", async () => {
+    await pushInput("", "should-not-store");
+    const entries = await getInputHistory("");
+    expect(entries).toHaveLength(0);
+  });
+});
+
+// ============================================================
+// Part 2: useInputHistory hook
+// ============================================================
+
+describe("#161 — useInputHistory hook", () => {
+  it("should navigate up through history", async () => {
+    await pushInput("agent:iclaw:main", "first");
+    await pushInput("agent:iclaw:main", "second");
+    await pushInput("agent:iclaw:main", "third");
+
+    const { result } = renderHook(() => useInputHistory("agent:iclaw:main"));
+
+    // Wait for async load
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    let text: string | null;
+    act(() => { text = result.current.navigateUp("current draft"); });
+    expect(text!).toBe("third");
+
+    act(() => { text = result.current.navigateUp("current draft"); });
+    expect(text!).toBe("second");
+
+    act(() => { text = result.current.navigateUp("current draft"); });
+    expect(text!).toBe("first");
+
+    // At top — should return null
+    act(() => { text = result.current.navigateUp("current draft"); });
+    expect(text).toBeNull();
+  });
+
+  it("should navigate down and restore draft", async () => {
+    await pushInput("agent:iclaw:main", "first");
+    await pushInput("agent:iclaw:main", "second");
+
+    const { result } = renderHook(() => useInputHistory("agent:iclaw:main"));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    let text: string | null;
+    act(() => { text = result.current.navigateUp("my draft"); });
+    expect(text!).toBe("second");
+
+    act(() => { text = result.current.navigateUp("my draft"); });
+    expect(text!).toBe("first");
+
+    // Navigate down
+    act(() => { text = result.current.navigateDown(); });
+    expect(text!).toBe("second");
+
+    // Navigate down past end → restore draft
+    act(() => { text = result.current.navigateDown(); });
+    expect(text!).toBe("my draft");
+
+    // Navigate down when not navigating → null
+    act(() => { text = result.current.navigateDown(); });
+    expect(text).toBeNull();
+  });
+
+  it("should save draft only on first navigateUp call", async () => {
+    await pushInput("agent:iclaw:main", "history-entry");
+
+    const { result } = renderHook(() => useInputHistory("agent:iclaw:main"));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    let text: string | null;
+    act(() => { text = result.current.navigateUp("original text"); });
+    expect(text!).toBe("history-entry");
+
+    // Navigate down → should restore "original text"
+    act(() => { text = result.current.navigateDown(); });
+    expect(text!).toBe("original text");
+  });
+
+  it("should reset navigation state after push", async () => {
+    await pushInput("agent:iclaw:main", "old-entry");
+
+    const { result } = renderHook(() => useInputHistory("agent:iclaw:main"));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Navigate into history
+    act(() => { result.current.navigateUp(""); });
+
+    // Push new entry → should reset
+    act(() => { result.current.push("new-entry"); });
+
+    // navigateDown should return null (not navigating)
+    let text: string | null;
+    act(() => { text = result.current.navigateDown(); });
+    expect(text).toBeNull();
+
+    // navigateUp should show the newly pushed entry
+    act(() => { text = result.current.navigateUp(""); });
+    expect(text!).toBe("new-entry");
+  });
+
+  it("should return null for empty history", async () => {
+    const { result } = renderHook(() => useInputHistory("agent:iclaw:main"));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    let text: string | null;
+    act(() => { text = result.current.navigateUp("draft"); });
+    expect(text).toBeNull();
+  });
+
+  it("should reset cursor when session changes", async () => {
+    await pushInput("agent:iclaw:main", "iclaw-msg");
+    await pushInput("agent:jarvis:main", "jarvis-msg");
+
+    const { result, rerender } = renderHook(
+      ({ sk }) => useInputHistory(sk),
+      { initialProps: { sk: "agent:iclaw:main" } },
+    );
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    let text: string | null;
+    act(() => { text = result.current.navigateUp(""); });
+    expect(text!).toBe("iclaw-msg");
+
+    // Switch to jarvis
+    rerender({ sk: "agent:jarvis:main" });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Should not be navigating anymore
+    act(() => { text = result.current.navigateDown(); });
+    expect(text).toBeNull();
+
+    // Navigate up should show jarvis history
+    act(() => { text = result.current.navigateUp(""); });
+    expect(text!).toBe("jarvis-msg");
+  });
+
+  it("should optimistically add to in-memory cache on push", async () => {
+    const { result } = renderHook(() => useInputHistory("agent:iclaw:main"));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    act(() => { result.current.push("optimistic-entry"); });
+
+    // Should be immediately navigable without waiting for IndexedDB
+    let text: string | null;
+    act(() => { text = result.current.navigateUp(""); });
+    expect(text!).toBe("optimistic-entry");
+  });
+
+  it("should skip duplicate consecutive pushes in memory", async () => {
+    const { result } = renderHook(() => useInputHistory("agent:iclaw:main"));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    act(() => {
+      result.current.push("same");
+      result.current.push("same");
+      result.current.push("same");
+    });
+
+    let text: string | null;
+    act(() => { text = result.current.navigateUp(""); });
+    expect(text!).toBe("same");
+
+    // No more entries
+    act(() => { text = result.current.navigateUp(""); });
+    expect(text).toBeNull();
+  });
+});
+
+// ============================================================
+// Part 3: Cursor position utilities for ArrowUp/Down
+// ============================================================
+
+describe("#161 — cursor position utilities", () => {
+  it("isCursorOnFirstLine: detects first line correctly", () => {
+    const isCursorOnFirstLine = (selectionStart: number, value: string): boolean => {
+      return !value.substring(0, selectionStart).includes("\n");
+    };
+
+    expect(isCursorOnFirstLine(5, "hello")).toBe(true);
+    expect(isCursorOnFirstLine(0, "hello")).toBe(true);
+    expect(isCursorOnFirstLine(3, "hello\nworld")).toBe(true);
+    expect(isCursorOnFirstLine(7, "hello\nworld")).toBe(false);
+    expect(isCursorOnFirstLine(0, "")).toBe(true);
+  });
+
+  it("isCursorOnLastLine: detects last line correctly", () => {
+    const isCursorOnLastLine = (selectionStart: number, value: string): boolean => {
+      return !value.substring(selectionStart).includes("\n");
+    };
+
+    expect(isCursorOnLastLine(5, "hello")).toBe(true);
+    expect(isCursorOnLastLine(7, "hello\nworld")).toBe(true);
+    expect(isCursorOnLastLine(3, "hello\nworld")).toBe(false);
+    expect(isCursorOnLastLine(0, "")).toBe(true);
+  });
+});

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -14,6 +14,7 @@ import { SkillPicker, BUILTIN_COMMANDS } from "./skill-picker";
 import { useSkills } from "@/lib/gateway/use-skills";
 import { useKeyboardHeight } from "@/lib/hooks/use-keyboard-height";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
+import { useInputHistory } from "@/hooks/use-input-history";
 import type { ReplyTo, AgentStatus } from "@/lib/gateway/hooks";
 
 /** Format agent status for display */
@@ -55,6 +56,7 @@ export function ChatInput({
   agentStatus,
   onOpenTopicHistory,
   onClearMessages,
+  sessionKey,
 }: {
   onSend: (text: string) => void;
   onAbort: () => void;
@@ -90,9 +92,12 @@ export function ChatInput({
   onOpenTopicHistory?: () => void;
   /** Callback to clear messages */
   onClearMessages?: () => void;
+  /** Session key for input history (#161) */
+  sessionKey?: string;
 }) {
   const keyboardHeight = useKeyboardHeight();
   const isMobile = useIsMobile();
+  const inputHistory = useInputHistory(sessionKey);
 
   const agentSlotFromAvatar = agentAvatar ? (
     <div
@@ -178,10 +183,13 @@ export function ChatInput({
 
   const handleSend = useCallback(() => {
     if (!canSend || disabled) return;
-    onSend(text.trim());
+    const trimmed = text.trim();
+    inputHistory.push(trimmed);
+    inputHistory.reset();
+    onSend(trimmed);
     setText("");
     if (storageKey) localStorage.removeItem(storageKey);
-  }, [text, disabled, onSend, canSend, storageKey]);
+  }, [text, disabled, onSend, canSend, storageKey, inputHistory]);
 
   const handleSkillSelect = useCallback((command: string) => {
     setText(command);
@@ -237,6 +245,48 @@ export function ChatInput({
         }
       }
 
+      // Input history navigation (#161): ArrowUp/Down when skill picker is closed
+      if (e.key === "ArrowUp" && !skillPickerOpen) {
+        const ta = e.target as HTMLTextAreaElement;
+        const beforeCursor = ta.value.substring(0, ta.selectionStart);
+        // Only navigate history when cursor is on the first line
+        if (!beforeCursor.includes("\n")) {
+          const prev = inputHistory.navigateUp(ta.value);
+          if (prev !== null) {
+            e.preventDefault();
+            setText(prev);
+            // Move cursor to end after state update
+            requestAnimationFrame(() => {
+              if (textareaRef.current) {
+                textareaRef.current.selectionStart = prev.length;
+                textareaRef.current.selectionEnd = prev.length;
+              }
+            });
+          }
+          return;
+        }
+      }
+
+      if (e.key === "ArrowDown" && !skillPickerOpen) {
+        const ta = e.target as HTMLTextAreaElement;
+        const afterCursor = ta.value.substring(ta.selectionStart);
+        // Only navigate history when cursor is on the last line
+        if (!afterCursor.includes("\n")) {
+          const next = inputHistory.navigateDown();
+          if (next !== null) {
+            e.preventDefault();
+            setText(next);
+            requestAnimationFrame(() => {
+              if (textareaRef.current) {
+                textareaRef.current.selectionStart = next.length;
+                textareaRef.current.selectionEnd = next.length;
+              }
+            });
+          }
+          return;
+        }
+      }
+
       if (e.key === "Escape") {
         e.preventDefault();
         (e.target as HTMLTextAreaElement).blur();
@@ -250,7 +300,7 @@ export function ChatInput({
         handleSend();
       }
     },
-    [handleSend, skillPickerOpen, filteredSkills, filteredBuiltins, totalPickerItems, skillSelectedIndex, handleSkillSelect, onSend, storageKey]
+    [handleSend, skillPickerOpen, filteredSkills, filteredBuiltins, totalPickerItems, skillSelectedIndex, handleSkillSelect, onSend, storageKey, inputHistory]
   );
 
   // Paste files

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -838,16 +838,7 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
             clearMessages();
           }
         }}
-      />
-
-      {/* Topic Name Dialog */}
-      <TopicNameDialog
-        open={topicNameDialogOpen}
-        onConfirm={(name) => {
-          setTopicNameDialogOpen(false);
-          createSessionForAgent(agentId, name);
-        }}
-        onCancel={() => setTopicNameDialogOpen(false)}
+        sessionKey={effectiveSessionKey}
       />
 
       {/* New Session Picker */}

--- a/apps/web/src/hooks/use-input-history.ts
+++ b/apps/web/src/hooks/use-input-history.ts
@@ -1,0 +1,164 @@
+/**
+ * useInputHistory — React hook for terminal-style input recall (#161).
+ *
+ * Provides push/navigate API for chat-input to cycle through previous
+ * inputs with Arrow Up / Arrow Down.
+ *
+ * Navigation model:
+ * - Arrow Up from the bottom (or when cursor === -1) → last entry
+ * - Arrow Up continues backward through history
+ * - Arrow Down moves forward; past the end restores the draft
+ * - Starting navigation saves the current textarea value as "draft"
+ * - Navigating past newest entry restores draft
+ */
+
+import { useRef, useCallback, useEffect } from "react";
+import {
+  pushInput,
+  getInputHistory,
+  MAX_ENTRIES_PER_SESSION,
+  type InputEntry,
+} from "@/lib/gateway/input-history-store";
+
+export interface UseInputHistoryReturn {
+  /**
+   * Record a sent message into history.
+   * Call this after successful send.
+   */
+  push: (text: string) => void;
+
+  /**
+   * Navigate up (older). Returns the text to display, or null if at top.
+   * On first call, saves `currentText` as the draft.
+   */
+  navigateUp: (currentText: string) => string | null;
+
+  /**
+   * Navigate down (newer). Returns the text to display, or null if at bottom.
+   * When navigating past the newest entry, returns the saved draft.
+   */
+  navigateDown: () => string | null;
+
+  /**
+   * Reset navigation state (e.g., after sending or when session changes).
+   */
+  reset: () => void;
+
+  /**
+   * Whether the user is currently browsing history.
+   */
+  isNavigating: boolean;
+}
+
+export function useInputHistory(sessionKey: string | undefined): UseInputHistoryReturn {
+  // In-memory cache of the history for this session, loaded on mount/change
+  const entriesRef = useRef<InputEntry[]>([]);
+  // Current navigation index (-1 = not navigating, 0..N-1 = in history)
+  const cursorRef = useRef<number>(-1);
+  // Draft saved when navigation starts
+  const draftRef = useRef<string>("");
+  // Track the session key to reset on change
+  const sessionKeyRef = useRef(sessionKey);
+
+  // Load history when session changes
+  useEffect(() => {
+    if (sessionKey !== sessionKeyRef.current) {
+      sessionKeyRef.current = sessionKey;
+      cursorRef.current = -1;
+      draftRef.current = "";
+    }
+
+    if (!sessionKey) {
+      entriesRef.current = [];
+      return;
+    }
+
+    let cancelled = false;
+    getInputHistory(sessionKey).then((entries) => {
+      if (!cancelled) {
+        entriesRef.current = entries;
+      }
+    });
+    return () => { cancelled = true; };
+  }, [sessionKey]);
+
+  const push = useCallback(
+    (text: string) => {
+      if (!sessionKey) return;
+      const trimmed = text.trim();
+      if (!trimmed) return;
+
+      // Optimistically add to in-memory cache (avoid re-read)
+      const last = entriesRef.current[entriesRef.current.length - 1];
+      if (!last || last.text !== trimmed) {
+        entriesRef.current.push({
+          sessionKey,
+          text: trimmed,
+          sentAt: Date.now(),
+        });
+        // Enforce cap in memory too
+        if (entriesRef.current.length > MAX_ENTRIES_PER_SESSION) {
+          entriesRef.current = entriesRef.current.slice(-MAX_ENTRIES_PER_SESSION);
+        }
+      }
+
+      // Reset navigation
+      cursorRef.current = -1;
+      draftRef.current = "";
+
+      // Persist asynchronously
+      pushInput(sessionKey, trimmed).catch(() => {});
+    },
+    [sessionKey],
+  );
+
+  const navigateUp = useCallback(
+    (currentText: string): string | null => {
+      const entries = entriesRef.current;
+      if (entries.length === 0) return null;
+
+      if (cursorRef.current === -1) {
+        // First navigation — save draft
+        draftRef.current = currentText;
+        cursorRef.current = entries.length - 1;
+      } else if (cursorRef.current > 0) {
+        cursorRef.current -= 1;
+      } else {
+        // Already at oldest — no change
+        return null;
+      }
+
+      return entries[cursorRef.current].text;
+    },
+    [],
+  );
+
+  const navigateDown = useCallback((): string | null => {
+    const entries = entriesRef.current;
+    if (cursorRef.current === -1) return null; // Not navigating
+
+    if (cursorRef.current < entries.length - 1) {
+      cursorRef.current += 1;
+      return entries[cursorRef.current].text;
+    }
+
+    // Past the end — restore draft
+    cursorRef.current = -1;
+    return draftRef.current;
+  }, []);
+
+  const reset = useCallback(() => {
+    cursorRef.current = -1;
+    draftRef.current = "";
+  }, []);
+
+  return {
+    push,
+    navigateUp,
+    navigateDown,
+    reset,
+    get isNavigating() {
+      return cursorRef.current !== -1;
+    },
+  };
+}

--- a/apps/web/src/lib/gateway/input-history-store.ts
+++ b/apps/web/src/lib/gateway/input-history-store.ts
@@ -1,0 +1,163 @@
+/**
+ * Input History Store — IndexedDB-based chat input history (#161).
+ *
+ * Persists user-typed messages per session key so the user can recall
+ * previous inputs with Arrow Up / Down, similar to a terminal shell.
+ *
+ * - Session-scoped: each sessionKey has its own ring of entries.
+ * - Capped: only the most recent MAX_ENTRIES_PER_SESSION are kept.
+ * - Deduped: consecutive identical inputs are not stored twice.
+ */
+
+const DB_NAME = "intelli-claw-input-history";
+const DB_VERSION = 1;
+const STORE_NAME = "inputs";
+
+/** Maximum entries per session to prevent unbounded growth */
+export const MAX_ENTRIES_PER_SESSION = 50;
+
+export interface InputEntry {
+  /** Session key (e.g. "agent:iclaw:main") */
+  sessionKey: string;
+  /** Auto-increment id (set by IndexedDB) */
+  id?: number;
+  /** The raw input text */
+  text: string;
+  /** When the input was sent (epoch ms) */
+  sentAt: number;
+}
+
+// --- IndexedDB helpers ---
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, {
+          keyPath: "id",
+          autoIncrement: true,
+        });
+        store.createIndex("bySessionKey", "sessionKey", { unique: false });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+// --- Public API ---
+
+/**
+ * Push a new input entry. Skips if:
+ * - text is empty/whitespace-only
+ * - text is identical to the most recent entry for this session
+ *
+ * Automatically trims entries beyond MAX_ENTRIES_PER_SESSION.
+ */
+export async function pushInput(
+  sessionKey: string,
+  text: string,
+): Promise<void> {
+  const trimmed = text.trim();
+  if (!sessionKey || !trimmed) return;
+
+  const db = await openDB();
+  try {
+    // Read existing entries to check for duplicate & enforce cap
+    const entries = await _getAllForSession(db, sessionKey);
+
+    // Skip consecutive duplicate
+    if (entries.length > 0 && entries[entries.length - 1].text === trimmed) {
+      db.close();
+      return;
+    }
+
+    // Insert new entry
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      const store = tx.objectStore(STORE_NAME);
+      store.add({ sessionKey, text: trimmed, sentAt: Date.now() } satisfies Omit<InputEntry, "id">);
+
+      // Evict oldest if over cap
+      const excess = entries.length + 1 - MAX_ENTRIES_PER_SESSION;
+      if (excess > 0) {
+        for (let i = 0; i < excess; i++) {
+          if (entries[i].id != null) {
+            store.delete(entries[i].id!);
+          }
+        }
+      }
+
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Get all input entries for a session, sorted oldest → newest (by id asc).
+ */
+export async function getInputHistory(
+  sessionKey: string,
+): Promise<InputEntry[]> {
+  if (!sessionKey) return [];
+  const db = await openDB();
+  try {
+    return await _getAllForSession(db, sessionKey);
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Clear all input history for a session.
+ */
+export async function clearInputHistory(
+  sessionKey: string,
+): Promise<void> {
+  if (!sessionKey) return;
+  const db = await openDB();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      const store = tx.objectStore(STORE_NAME);
+      const index = store.index("bySessionKey");
+      const req = index.openCursor(sessionKey);
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (cursor) {
+          cursor.delete();
+          cursor.continue();
+        }
+      };
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+// --- Internal ---
+
+function _getAllForSession(
+  db: IDBDatabase,
+  sessionKey: string,
+): Promise<InputEntry[]> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const index = tx.objectStore(STORE_NAME).index("bySessionKey");
+    const req = index.getAll(sessionKey);
+    req.onsuccess = () => {
+      const entries = (req.result as InputEntry[]) || [];
+      // Sort by auto-increment id (oldest first)
+      entries.sort((a, b) => (a.id ?? 0) - (b.id ?? 0));
+      resolve(entries);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}


### PR DESCRIPTION
## 기능
터미널 셸처럼 이전에 입력했던 채팅 내용을 **↑/↓ 화살표**로 불러올 수 있는 기능.

## 동작 방식

| 조작 | 동작 |
|------|------|
| **Arrow Up** (첫 번째 줄에서) | 이전 입력으로 이동 |
| **Arrow Down** (마지막 줄에서) | 다음 입력으로 이동 |
| 최신 입력을 지나서 ↓ | 원래 작성 중이던 텍스트(draft) 복원 |
| 메시지 전송 | 히스토리에 자동 저장 + 탐색 리셋 |

### 세부 사항
- **세션별 분리**: 각 에이전트 세션마다 독립적인 히스토리
- **최대 50건**: 세션당 최근 50개 입력만 보관 (IndexedDB)
- **중복 제거**: 연속으로 같은 내용 입력 시 1건만 저장
- **멀티라인 호환**: 커서가 첫 줄/마지막 줄에 있을 때만 히스토리 탐색, 그 외엔 일반 커서 이동
- **Skill picker 우선**: `/` 자동완성 열려있으면 기존 picker 네비게이션 유지
- **영속성**: IndexedDB 기반 — 새로고침/앱 재시작 후에도 유지

## 변경 파일

| 파일 | 설명 |
|------|------|
| `input-history-store.ts` | IndexedDB 저장소 (push/get/clear, 50건 cap, dedup) |
| `use-input-history.ts` | React hook (navigateUp/Down, draft 보존, optimistic cache) |
| `chat-input.tsx` | ArrowUp/Down 키 핸들링 + sessionKey prop |
| `chat-panel.tsx` | sessionKey 전달 |

## 테스트
- 19건 신규 (store 9 + hook 8 + cursor utils 2)
- 전체 907건 통과, 빌드 정상

Closes #161