### PR TITLE
fix(#142): Web 멀티 윈도우 시 localStorage 키 충돌 방지

### DIFF
--- a/apps/web/src/__tests__/hooks-merge-pipeline.test.ts
+++ b/apps/web/src/__tests__/hooks-merge-pipeline.test.ts
@@ -273,7 +273,9 @@ describe("Merge pipeline", () => {
   });
 
   it("queue dedup: stale queue items matching history are removed from localStorage", async () => {
-    const queueKey = "awf:queue:test:agent";
+    // #142: queueStorageKey now includes windowStoragePrefix()
+    const { windowStoragePrefix } = await import("@/lib/utils");
+    const queueKey = `awf:${windowStoragePrefix()}queue:test:agent`;
     mockLocal.setItem(
       queueKey,
       JSON.stringify([

--- a/apps/web/src/__tests__/issue-142-multiwindow-storage.test.ts
+++ b/apps/web/src/__tests__/issue-142-multiwindow-storage.test.ts
@@ -1,0 +1,267 @@
+/**
+ * #142 — 멀티 윈도우 시 localStorage 키 충돌 방지
+ *
+ * Web 환경에서 여러 브라우저 탭을 열면 windowStoragePrefix()가 항상 ""을 반환하여
+ * 모든 탭이 동일한 localStorage 키를 공유하는 문제.
+ *
+ * 검증 대상:
+ * 1. windowStoragePrefix() — Web 탭별 고유 prefix 생성
+ * 2. queueStorageKey — prefix 적용 여부
+ * 3. 레거시 마이그레이션 — 기존 "" prefix → 새 prefix 이전
+ * 4. 공유/격리 정책 — 전역 키는 prefix 없이 유지
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { windowStoragePrefix } from "@/lib/utils";
+import { resolveInitialSessionState } from "@/lib/session-continuity";
+import fs from "fs";
+import path from "path";
+
+// ─── windowStoragePrefix 테스트 ───────────────────────────────────
+
+describe("#142 — windowStoragePrefix() Web 탭 격리", () => {
+  beforeEach(() => {
+    // Clear the window id from sessionStorage
+    sessionStorage.removeItem("__iclaw_window_id__");
+    delete (window as any).electronAPI;
+  });
+
+  it("should return non-empty prefix in Web environment (no electronAPI)", () => {
+    const prefix = windowStoragePrefix();
+    expect(prefix).not.toBe("");
+    expect(prefix.length).toBeGreaterThan(0);
+  });
+
+  it("should return consistent prefix within the same tab (idempotent)", () => {
+    const first = windowStoragePrefix();
+    const second = windowStoragePrefix();
+    expect(first).toBe(second);
+  });
+
+  it("should store tab ID in sessionStorage under __iclaw_window_id__", () => {
+    windowStoragePrefix();
+    const stored = sessionStorage.getItem("__iclaw_window_id__");
+    expect(stored).toBeTruthy();
+    expect(typeof stored).toBe("string");
+  });
+
+  it("prefix should end with colon for key namespacing", () => {
+    const prefix = windowStoragePrefix();
+    expect(prefix.endsWith(":")).toBe(true);
+  });
+
+  it("should return empty prefix for Electron window 0 (backward compat)", () => {
+    (window as any).electronAPI = { windowId: 0 };
+    const prefix = windowStoragePrefix();
+    expect(prefix).toBe("");
+  });
+
+  it("should return 'wN:' prefix for Electron window N > 0", () => {
+    (window as any).electronAPI = { windowId: 3 };
+    const prefix = windowStoragePrefix();
+    expect(prefix).toBe("w3:");
+  });
+
+  it("should generate prefix based on sessionStorage (different tabs get different IDs)", () => {
+    // First "tab"
+    const prefix1 = windowStoragePrefix();
+    const id1 = sessionStorage.getItem("__iclaw_window_id__");
+
+    // Simulate second tab — clear sessionStorage window ID
+    sessionStorage.removeItem("__iclaw_window_id__");
+
+    // After clearing, next call should generate a NEW id
+    const prefix2 = windowStoragePrefix();
+    const id2 = sessionStorage.getItem("__iclaw_window_id__");
+
+    expect(id1).toBeTruthy();
+    expect(id2).toBeTruthy();
+    expect(id2).not.toBe(id1);
+  });
+
+  it("prefix should start with 't' for Web tabs", () => {
+    const prefix = windowStoragePrefix();
+    expect(prefix.startsWith("t")).toBe(true);
+  });
+});
+
+// ─── queueStorageKey prefix 테스트 ────────────────────────────────
+
+describe("#142 — queueStorageKey must include windowStoragePrefix", () => {
+  it("source code should include windowStoragePrefix in queueStorageKey construction", () => {
+    const hooksPath = path.resolve(__dirname, "../lib/gateway/hooks.tsx");
+    const source = fs.readFileSync(hooksPath, "utf-8");
+
+    const lines = source.split("\n");
+    const queueKeyLine = lines.find(
+      (line) =>
+        line.includes("queueStorageKey") &&
+        line.includes("awf:") &&
+        line.includes("queue")
+    );
+    expect(queueKeyLine).toBeDefined();
+    expect(queueKeyLine).toContain("windowStoragePrefix()");
+  });
+});
+
+// ─── 레거시 마이그레이션 테스트 ──────────────────────────────────
+
+describe("#142 — Legacy key migration", () => {
+  beforeEach(() => {
+    sessionStorage.removeItem("__iclaw_window_id__");
+    delete (window as any).electronAPI;
+  });
+
+  it("should read legacy (no-prefix) key as fallback for agent-remembered session", () => {
+    // Build an in-memory store simulating existing user data
+    const store: Record<string, string> = {
+      "awf:lastSessionKey:test-agent": "agent:test-agent:main",
+    };
+    const getItem = (k: string) => store[k] ?? null;
+
+    const prefix = windowStoragePrefix();
+    const state = resolveInitialSessionState({
+      windowPrefix: prefix,
+      defaultAgentId: "test-agent",
+      getItem,
+    });
+
+    // Should find the session via agentRememberedSessionKey fallback
+    expect(state.sessionKey).toBe("agent:test-agent:main");
+  });
+
+  it("should prioritize scoped key over legacy key", () => {
+    const prefix = windowStoragePrefix();
+
+    const store: Record<string, string> = {
+      // Legacy agent data
+      "awf:agentId": "legacy-agent",
+      // Scoped agent data (should win)
+      [`awf:${prefix}agentId`]: "scoped-agent",
+      // Session keys for both
+      "awf:lastSessionKey:scoped-agent": "agent:scoped:s1",
+      "awf:lastSessionKey:legacy-agent": "agent:legacy:s1",
+    };
+    const getItem = (k: string) => store[k] ?? null;
+
+    const state = resolveInitialSessionState({
+      windowPrefix: prefix,
+      defaultAgentId: "default",
+      getItem,
+    });
+
+    expect(state.agentId).toBe("scoped-agent");
+  });
+
+  it("should fall back to legacy agentId when scoped key is missing (upgrade path)", () => {
+    const prefix = windowStoragePrefix();
+
+    const store: Record<string, string> = {
+      // Only legacy data — simulating user who had single-tab before upgrade
+      "awf:agentId": "legacy-agent",
+      "awf:lastSessionKey:legacy-agent": "agent:legacy:session1",
+    };
+    const getItem = (k: string) => store[k] ?? null;
+
+    const state = resolveInitialSessionState({
+      windowPrefix: prefix,
+      defaultAgentId: "default",
+      getItem,
+    });
+
+    // Should find legacy-agent via fallback
+    expect(state.agentId).toBe("legacy-agent");
+    expect(state.sessionKey).toBe("agent:legacy:session1");
+  });
+});
+
+// ─── 공유 키 격리 정책 테스트 ─────────────────────────────────────
+
+describe("#142 — Shared keys must NOT use window prefix", () => {
+  it("gateway config key should not include window prefix", () => {
+    const hooksPath = path.resolve(__dirname, "../lib/gateway/hooks.tsx");
+    const source = fs.readFileSync(hooksPath, "utf-8");
+
+    const lines = source.split("\n");
+    const configLines = lines.filter(
+      (line) =>
+        line.includes("GATEWAY_CONFIG_STORAGE_KEY") &&
+        line.includes("localStorage")
+    );
+    for (const line of configLines) {
+      expect(line).not.toContain("windowStoragePrefix");
+    }
+  });
+
+  it("hidden-sessions key should not include window prefix", () => {
+    const hiddenPath = path.resolve(
+      __dirname,
+      "../lib/gateway/hidden-sessions.ts"
+    );
+    const source = fs.readFileSync(hiddenPath, "utf-8");
+    expect(source).toContain('"awf:hidden-sessions"');
+    expect(source).not.toContain("windowStoragePrefix");
+  });
+
+  it("shortcuts key should not include window prefix", () => {
+    const shortcutsPath = path.resolve(__dirname, "../lib/shortcuts.ts");
+    const source = fs.readFileSync(shortcutsPath, "utf-8");
+    expect(source).toContain('"awf:custom-shortcuts"');
+    expect(source).not.toContain("windowStoragePrefix");
+  });
+});
+
+// ─── 격리 대상 키 통합 검증 ───────────────────────────────────────
+
+describe("#142 — Storage key isolation integration", () => {
+  beforeEach(() => {
+    sessionStorage.removeItem("__iclaw_window_id__");
+    delete (window as any).electronAPI;
+  });
+
+  it("two tabs should produce independent prefixes for localStorage keys", () => {
+    // Tab 1
+    const prefix1 = windowStoragePrefix();
+    expect(prefix1).not.toBe("");
+
+    // Simulate Tab 2
+    sessionStorage.removeItem("__iclaw_window_id__");
+    const prefix2 = windowStoragePrefix();
+
+    // Different prefixes
+    expect(prefix1).not.toBe(prefix2);
+
+    // Using them as key namespaces produces distinct keys
+    expect(`awf:${prefix1}sessionKey`).not.toBe(`awf:${prefix2}sessionKey`);
+    expect(`awf:${prefix1}agentId`).not.toBe(`awf:${prefix2}agentId`);
+    expect(`awf:${prefix1}draft:panel-1`).not.toBe(`awf:${prefix2}draft:panel-1`);
+  });
+
+  it("queue keys source should use windowStoragePrefix", () => {
+    const hooksPath = path.resolve(__dirname, "../lib/gateway/hooks.tsx");
+    const source = fs.readFileSync(hooksPath, "utf-8");
+
+    const lines = source.split("\n");
+    const queueLine = lines.find(
+      (l) =>
+        l.includes("queueStorageKey") &&
+        l.includes("=") &&
+        l.includes("queue")
+    );
+    expect(queueLine).toBeDefined();
+    expect(queueLine).toContain("windowStoragePrefix");
+  });
+
+  it("hooks.tsx should import windowStoragePrefix from utils", () => {
+    const hooksPath = path.resolve(__dirname, "../lib/gateway/hooks.tsx");
+    const source = fs.readFileSync(hooksPath, "utf-8");
+    const importLine = source
+      .split("\n")
+      .find(
+        (l) =>
+          l.includes("import") &&
+          l.includes("windowStoragePrefix") &&
+          l.includes("utils")
+      );
+    expect(importLine).toBeDefined();
+  });
+});

--- a/apps/web/src/lib/gateway/hooks.tsx
+++ b/apps/web/src/lib/gateway/hooks.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode,
 } from "react";
 import { getMimeType } from "@/lib/mime-types";
+import { windowStoragePrefix } from "@/lib/utils";
 import { validateMediaPath, sanitizeAttachmentPath } from "@/lib/platform/media-path";
 import { platform } from "@/lib/platform";
 import type {
@@ -580,7 +581,8 @@ export function useChat(sessionKey?: string) {
   // - Writing phase (content streaming): 90s — allows long responses to complete
   const THINKING_TIMEOUT_MS = 45_000;
   const WRITING_TIMEOUT_MS = 90_000;
-  const queueStorageKey = sessionKey ? `awf:queue:${sessionKey}` : null;
+  // #142: Scope queue key per browser tab to prevent cross-tab queue collision
+  const queueStorageKey = sessionKey ? `awf:${windowStoragePrefix()}queue:${sessionKey}` : null;
   const pendingStreamStorageKey = sessionKey ? `${PENDING_STREAM_SESSION_KEY_PREFIX}${sessionKey}` : null;
 
   const clearPersistedPendingStream = useCallback(() => {

--- a/apps/web/src/lib/session-continuity.ts
+++ b/apps/web/src/lib/session-continuity.ts
@@ -33,7 +33,9 @@ export function resolveInitialSessionState(params: {
   // Post SplitView removal: scoped prefix matches chat-panel's storagePrefix
   const scopedPrefix = `awf:${windowPrefix}`;
   const scopedAgent = getItem(`${scopedPrefix}agentId`);
-  const agentId = scopedAgent || defaultAgentId;
+  // #142: Fall back to legacy no-prefix key for users upgrading from single-tab era
+  const legacyAgent = windowPrefix ? getItem("awf:agentId") : null;
+  const agentId = scopedAgent || legacyAgent || defaultAgentId;
 
   const keys = buildSessionContinuityKeys({ windowPrefix, agentId });
 

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -6,13 +6,28 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
- * Returns a localStorage key prefix scoped to the current Electron window.
- * Window 0 (the first window / web mode) uses no prefix for backward compatibility.
+ * Per-window localStorage key prefix.
+ *
+ * - **Electron**: uses `electronAPI.windowId` (window 0 = "" for backward compat).
+ * - **Web**: generates a unique tab ID stored in `sessionStorage` (per-tab,
+ *   survives refresh, new tab gets new ID). Fixes #142 — multiple browser tabs
+ *   sharing the same localStorage keys.
  */
 export function windowStoragePrefix(): string {
   if (typeof window === "undefined") return "";
+
+  // Electron — existing behavior preserved
   const api = (window as unknown as Record<string, unknown>).electronAPI as { windowId?: number } | undefined;
-  const wid = api?.windowId;
-  if (wid === undefined || wid === 0) return "";
-  return `w${wid}:`;
+  if (api?.windowId != null) {
+    return api.windowId === 0 ? "" : `w${api.windowId}:`;
+  }
+
+  // Web — per-tab unique prefix via sessionStorage
+  const KEY = "__iclaw_window_id__";
+  let id = sessionStorage.getItem(KEY);
+  if (!id) {
+    id = `t${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+    sessionStorage.setItem(KEY, id);
+  }
+  return `${id}:`;
 }


### PR DESCRIPTION
Closes #142

## 근본 원인

`windowStoragePrefix()`가 Web 환경에서 항상 `""`을 반환 → 모든 브라우저 탭이 동일한 localStorage 키 공유 → 세션 선택, 에이전트, 입력 초안, 전송 큐가 탭 간 간섭.

## Changes (5 files, +296/-8)

### 1. `utils.ts` — `windowStoragePrefix()` Web 분기 추가
- `sessionStorage`에 탭 고유 ID 생성·저장 (`t{timestamp36}{random4}`)
- 새 탭 = 새 ID, 새로고침 = 동일 ID 유지
- Electron 기존 동작 100% 보존 (`windowId: 0 → ""`, `windowId: N → wN:`)

### 2. `hooks.tsx` — `queueStorageKey` prefix 적용
- `awf:queue:{sk}` → `awf:${windowStoragePrefix()}queue:{sk}`
- 이슈에서 식별된 충돌 키 중 유일하게 prefix가 누락되어 있던 곳

### 3. `session-continuity.ts` — 레거시 agentId fallback
- 기존 단일 탭 사용자의 `awf:agentId` 데이터를 새 prefix 환경에서도 읽을 수 있도록 fallback 추가
- scoped key 우선 → legacy key fallback → defaultAgentId

### 격리/공유 정책

| 데이터 | 정책 | 이유 |
|--------|------|------|
| sessionKey, agentId, draft, queue | **격리** | 각 탭 독립 조작 |
| gateway config, hidden-sessions, shortcuts, lastSessionKey | **공유 유지** | 전역 사용자 설정 |
| pending-stream, deviceId | **이미 격리** | sessionStorage 사용 중 |

### 이슈에서 놓친 추가 수정

1. **`queueStorageKey` prefix 누락**: 이슈 본문에 "검토" 수준으로만 언급되었으나, 실제 코드에서 `windowStoragePrefix()` 미적용 확인 → 수정
2. **레거시 `agentId` fallback**: 기존 사용자가 업그레이드 시 `awf:agentId` 데이터 유실 가능 → `session-continuity.ts`에 fallback 체인 추가

## Tests
- **18건 신규** (prefix 생성 8건, queueKey 1건, 레거시 마이그레이션 3건, 공유 정책 3건, 통합 격리 3건)
- 기존 `hooks-merge-pipeline` 테스트 1건 업데이트
- **전체 925건 통과**, Vite 빌드 정상