### PR TITLE
feat: Phase 4 — Cmd+T topic name input dialog (#172)

### DIFF
--- a/apps/web/e2e/topic-name.spec.ts
+++ b/apps/web/e2e/topic-name.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * E2E tests for Phase 4: Cmd+T topic name input dialog (#172)
+ */
+import { test, expect } from "./helpers/fixtures";
+
+/**
+ * Dispatch Cmd+T / Ctrl+T depending on the platform detected by the app.
+ * Playwright Desktop Chrome uses a non-Mac user agent, so isMac = false → Ctrl+T.
+ * We dispatch both metaKey and ctrlKey to cover both cases.
+ */
+async function pressNewTab(page: import("@playwright/test").Page) {
+  await page.evaluate(() => {
+    // Dispatch Ctrl+T (non-Mac shortcut)
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "t", ctrlKey: true, bubbles: true }),
+    );
+  });
+}
+
+test.describe("Topic Name Dialog — Phase 4", () => {
+  test("Cmd+T opens the name dialog", async ({ mockGateway }) => {
+    const page = await mockGateway({
+      agentId: "default",
+      sessions: [
+        { key: "agent:default:main", label: "Main", updatedAt: Date.now() },
+      ],
+    });
+
+    await page.waitForTimeout(500);
+    await pressNewTab(page);
+
+    // The dialog should appear
+    const dialog = page.locator("[data-testid='topic-name-dialog']");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    const input = page.locator("[data-testid='topic-name-input']");
+    await expect(input).toBeVisible();
+    await expect(input).toBeFocused();
+  });
+
+  test("typing name + Enter creates topic with that name", async ({ mockGateway }) => {
+    const page = await mockGateway({
+      agentId: "default",
+      sessions: [
+        { key: "agent:default:main", label: "Main", updatedAt: Date.now() },
+      ],
+    });
+
+    await page.waitForTimeout(500);
+    await pressNewTab(page);
+
+    const input = page.locator("[data-testid='topic-name-input']");
+    await expect(input).toBeVisible({ timeout: 3000 });
+
+    // Type a topic name and press Enter
+    await input.fill("My Test Topic");
+    await input.press("Enter");
+
+    // Dialog should close
+    const dialog = page.locator("[data-testid='topic-name-dialog']");
+    await expect(dialog).not.toBeVisible({ timeout: 2000 });
+
+    // Check that the session key contains the sanitized name
+    await page.waitForTimeout(500);
+    const sessionKey = await page.evaluate(() => {
+      const entries: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key) {
+          const val = localStorage.getItem(key) || "";
+          if (val.includes(":topic:")) entries.push(val);
+        }
+      }
+      return entries;
+    });
+
+    expect(sessionKey.length).toBeGreaterThan(0);
+    expect(sessionKey.some((k) => k.includes(":topic:my-test-topic"))).toBe(true);
+  });
+
+  test("pressing Escape cancels (no new topic)", async ({ mockGateway }) => {
+    const page = await mockGateway({
+      agentId: "default",
+      sessions: [
+        { key: "agent:default:main", label: "Main", updatedAt: Date.now() },
+      ],
+    });
+
+    await page.waitForTimeout(500);
+    await pressNewTab(page);
+
+    const dialog = page.locator("[data-testid='topic-name-dialog']");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    // Press Escape
+    await page.keyboard.press("Escape");
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 2000 });
+
+    // No new topic session should have been created
+    const topicKeys = await page.evaluate(() => {
+      const keys: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key) {
+          const val = localStorage.getItem(key) || "";
+          if (val.includes(":topic:")) keys.push(val);
+        }
+      }
+      return keys;
+    });
+
+    expect(topicKeys.length).toBe(0);
+  });
+
+  test("empty input + Enter creates topic with auto-generated name", async ({ mockGateway }) => {
+    const page = await mockGateway({
+      agentId: "default",
+      sessions: [
+        { key: "agent:default:main", label: "Main", updatedAt: Date.now() },
+      ],
+    });
+
+    await page.waitForTimeout(500);
+    await pressNewTab(page);
+
+    const input = page.locator("[data-testid='topic-name-input']");
+    await expect(input).toBeVisible({ timeout: 3000 });
+
+    // Press Enter without typing anything
+    await input.press("Enter");
+
+    // Dialog should close
+    const dialog = page.locator("[data-testid='topic-name-dialog']");
+    await expect(dialog).not.toBeVisible({ timeout: 2000 });
+
+    // A topic session should have been created with auto-generated ID
+    await page.waitForTimeout(500);
+    const topicKeys = await page.evaluate(() => {
+      const keys: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key) {
+          const val = localStorage.getItem(key) || "";
+          if (val.includes(":topic:")) keys.push(val);
+        }
+      }
+      return keys;
+    });
+
+    expect(topicKeys.length).toBeGreaterThan(0);
+    // Auto-generated ID is base36 format (alphanumeric)
+    const topicId = topicKeys[0].split(":topic:")[1];
+    expect(topicId).toBeTruthy();
+    expect(topicId.length).toBeGreaterThan(0);
+  });
+
+  test("new topic with custom name appears in tab bar", async ({ mockGateway }) => {
+    const page = await mockGateway({
+      agentId: "default",
+      sessions: [
+        { key: "agent:default:main", label: "Main", updatedAt: Date.now() },
+      ],
+    });
+
+    await page.waitForTimeout(500);
+    await pressNewTab(page);
+
+    const input = page.locator("[data-testid='topic-name-input']");
+    await expect(input).toBeVisible({ timeout: 3000 });
+
+    await input.fill("Feature Work");
+    await input.press("Enter");
+
+    await page.waitForTimeout(1000);
+
+    // The tab bar should contain the new topic label
+    const tabBar = page.locator("[data-chat-panel]");
+    const tabText = await tabBar.textContent();
+    expect(tabText).toBeTruthy();
+  });
+});

--- a/apps/web/src/__tests__/topic-name-dialog.test.ts
+++ b/apps/web/src/__tests__/topic-name-dialog.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * sanitizeTopicName: user input → valid topic ID
+ * - lowercase
+ * - spaces → hyphens
+ * - remove special chars (keep alphanumeric, hangul, hyphens)
+ * - max 50 chars
+ * - empty/whitespace-only → null (fallback to auto-generated)
+ */
+function importSanitize() {
+  // Will be implemented in topic-name-dialog.tsx
+  return import("@/components/chat/topic-name-dialog").then((m) => m.sanitizeTopicName);
+}
+
+describe("sanitizeTopicName", () => {
+  it("converts spaces to hyphens and lowercases", async () => {
+    const sanitize = await importSanitize();
+    expect(sanitize("My Cool Topic")).toBe("my-cool-topic");
+  });
+
+  it("preserves hangul characters", async () => {
+    const sanitize = await importSanitize();
+    expect(sanitize("버그 수정")).toBe("버그-수정");
+  });
+
+  it("removes special characters", async () => {
+    const sanitize = await importSanitize();
+    expect(sanitize("test@#$%!")).toBe("test");
+  });
+
+  it("handles mixed hangul, alphanumeric, and special chars", async () => {
+    const sanitize = await importSanitize();
+    expect(sanitize("API 연동 #v2")).toBe("api-연동-v2");
+  });
+
+  it("collapses consecutive hyphens", async () => {
+    const sanitize = await importSanitize();
+    expect(sanitize("hello   world")).toBe("hello-world");
+    expect(sanitize("a---b")).toBe("a-b");
+  });
+
+  it("trims leading/trailing hyphens", async () => {
+    const sanitize = await importSanitize();
+    expect(sanitize(" hello ")).toBe("hello");
+    expect(sanitize("--test--")).toBe("test");
+  });
+
+  it("truncates to max 50 characters", async () => {
+    const sanitize = await importSanitize();
+    const long = "a".repeat(60);
+    const result = sanitize(long);
+    expect(result!.length).toBeLessThanOrEqual(50);
+    expect(result).toBe("a".repeat(50));
+  });
+
+  it("returns null for empty input", async () => {
+    const sanitize = await importSanitize();
+    expect(sanitize("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only input", async () => {
+    const sanitize = await importSanitize();
+    expect(sanitize("   ")).toBeNull();
+  });
+
+  it("returns null for special-chars-only input", async () => {
+    const sanitize = await importSanitize();
+    expect(sanitize("@#$%!")).toBeNull();
+  });
+
+  it("preserves numbers", async () => {
+    const sanitize = await importSanitize();
+    expect(sanitize("sprint 42")).toBe("sprint-42");
+  });
+
+  it("handles single character", async () => {
+    const sanitize = await importSanitize();
+    expect(sanitize("A")).toBe("a");
+  });
+});

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -21,6 +21,7 @@ import { useSwipeGesture, getNextAgentIndex } from "@/lib/hooks/use-swipe-gestur
 import { NewSessionPicker, AgentManager } from "@/components/settings/agent-manager";
 import { SessionManagerPanel } from "./session-manager-panel";
 import { TopicHistory } from "./topic-history";
+import { TopicNameDialog } from "./topic-name-dialog";
 import { resolveInitialSessionState, getRememberedSessionForAgent } from "@/lib/session-continuity";
 import { platform } from "@/lib/platform";
 
@@ -91,6 +92,7 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
   const [agentManagerOpen, setAgentManagerOpen] = useState(false);
   const [sessionManagerOpen, setSessionManagerOpen] = useState(false);
   const [topicHistoryOpen, setTopicHistoryOpen] = useState(false);
+  const [topicNameDialogOpen, setTopicNameDialogOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
 
   // Swipe gesture for mobile agent switching
@@ -193,10 +195,10 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
         e.preventDefault();
         abort();
       }
-      // Cmd+T: create new session tab
+      // Cmd+T: open topic name dialog
       if (matchesShortcutId(e, "new-tab")) {
         e.preventDefault();
-        createSessionForAgent(agentId);
+        setTopicNameDialogOpen(true);
         return;
       }
       // Cmd+1~9: switch to specific tab (9 = last tab)
@@ -459,8 +461,12 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
       // Use sendCommand instead of sendMessage to avoid force-setting streaming=true.
       // If gateway starts an agent run, event handlers set streaming naturally.
 
-      // /new, /reset
-      if (trimmed === "/new" || trimmed === "/reset" || trimmed.startsWith("/new ") || trimmed.startsWith("/reset ")) {
+      // /new → open topic name dialog; /reset → gateway command
+      if (trimmed === "/new") {
+        setTopicNameDialogOpen(true);
+        return;
+      }
+      if (trimmed === "/reset" || trimmed.startsWith("/new ") || trimmed.startsWith("/reset ")) {
         addLocalMessage(text, "user");
         sendCommand(text);
         refreshSessions();
@@ -581,11 +587,11 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
   };
 
     const handleNewSession = () => {
-    createSessionForAgent(agentId);
+    setTopicNameDialogOpen(true);
   };
 
-  const createSessionForAgent = async (selectedAgentId: string) => {
-    const topicId = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+  const createSessionForAgent = async (selectedAgentId: string, topicName?: string | null) => {
+    const topicId = topicName || (Date.now().toString(36) + Math.random().toString(36).slice(2, 6));
     const newKey = `agent:${selectedAgentId}:main:topic:${topicId}`;
 
     // Switch agent context if different
@@ -599,11 +605,12 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
     setSessionKey(newKey);
 
     // Pre-label the thread
+    const label = topicName || makeDefaultThreadLabel(selectedAgentId);
     if (client && isConnected) {
       try {
         await client.request("sessions.patch", {
           key: newKey,
-          label: makeDefaultThreadLabel(selectedAgentId),
+          label,
         });
       } catch {
         // ignore; auto-labeled on first message
@@ -742,6 +749,16 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
         tokenPercent={(currentSession as any)?.percentUsed as number | undefined}
         replyingTo={replyingTo}
         onClearReply={clearReplyTo}
+      />
+
+      {/* Topic Name Dialog */}
+      <TopicNameDialog
+        open={topicNameDialogOpen}
+        onConfirm={(name) => {
+          setTopicNameDialogOpen(false);
+          createSessionForAgent(agentId, name);
+        }}
+        onCancel={() => setTopicNameDialogOpen(false)}
       />
 
       {/* New Session Picker */}

--- a/apps/web/src/components/chat/topic-name-dialog.tsx
+++ b/apps/web/src/components/chat/topic-name-dialog.tsx
@@ -1,0 +1,109 @@
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
+
+export function sanitizeTopicName(raw: string): string | null {
+  let s = raw
+    .trim()
+    .toLowerCase()
+    // replace spaces with hyphens
+    .replace(/\s+/g, "-")
+    // remove anything that isn't alphanumeric, hangul (가-힣,ㄱ-ㅎ,ㅏ-ㅣ), or hyphens
+    .replace(/[^a-z0-9가-힣ㄱ-ㅎㅏ-ㅣ\-]/g, "")
+    // collapse consecutive hyphens
+    .replace(/-{2,}/g, "-")
+    // trim leading/trailing hyphens
+    .replace(/^-+|-+$/g, "");
+
+  if (!s) return null;
+  if (s.length > 50) s = s.slice(0, 50);
+  return s;
+}
+
+interface TopicNameDialogProps {
+  open: boolean;
+  onConfirm: (name: string | null) => void;
+  onCancel: () => void;
+}
+
+export function TopicNameDialog({ open, onConfirm, onCancel }: TopicNameDialogProps) {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setValue("");
+      // auto-focus after portal mount
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  const handleSubmit = useCallback(() => {
+    const sanitized = sanitizeTopicName(value);
+    onConfirm(sanitized);
+  }, [value, onConfirm]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  const container = document.getElementById("portal-root") || document.body;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[200]" role="dialog" aria-modal="true" data-testid="topic-name-dialog">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onCancel} />
+      <div className="absolute left-1/2 top-1/2 w-[min(92vw,400px)] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-zinc-700 bg-zinc-900 p-5 shadow-2xl">
+        <h3 className="mb-3 text-sm font-semibold text-zinc-100">
+          새 토픽 이름
+        </h3>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+        >
+          <input
+            ref={inputRef}
+            type="text"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="토픽 이름 입력..."
+            maxLength={50}
+            className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 outline-none focus:border-zinc-500 transition"
+            data-testid="topic-name-input"
+          />
+          <p className="mt-1.5 text-[11px] text-zinc-500">
+            비워두면 자동 생성됩니다. Enter 확인, Esc 취소
+          </p>
+          <div className="mt-3 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-md px-3 py-1.5 text-xs text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200 transition"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              className="rounded-md bg-zinc-700 px-3 py-1.5 text-xs text-zinc-100 hover:bg-zinc-600 transition"
+            >
+              생성
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    container,
+  );
+}


### PR DESCRIPTION
## 변경 요약
Cmd+T 새 토픽 생성 시 이름 입력 다이얼로그 추가.

### 주요 동작
- Cmd+T: 이름 입력 다이얼로그 표시
- 이름 입력 + Enter: 해당 이름으로 토픽 생성
- 빈 입력 + Enter: 자동 생성 ID 사용 (기존 동작)
- Escape: 취소
- 이름 sanitize: 공백→하이픈, 소문자, 특수문자 제거

### 테스트
- 단위 테스트 + E2E 통과

Closes #172
Related: #150