### PR TITLE
feat: move session meta from header to chat input area (#171)

### DIFF
--- a/apps/web/src/__tests__/issue-171-header-meta-move.test.ts
+++ b/apps/web/src/__tests__/issue-171-header-meta-move.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Issue #171 — Session meta info moved from header to chat input bar
+ *
+ * Validates that:
+ * 1. ChatHeader no longer exports/uses session meta elements (sessionType, topicCount, clearMessages, agentStatus indicator)
+ * 2. ChatInput accepts and renders session meta props
+ * 3. formatAgentStatus works correctly in chat-input
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const COMPONENTS_DIR = path.resolve(__dirname, "../components/chat");
+
+function readComponent(name: string): string {
+  return fs.readFileSync(path.join(COMPONENTS_DIR, name), "utf-8");
+}
+
+describe("Issue #171: Header meta → Chat input migration", () => {
+  const headerSrc = readComponent("chat-header.tsx");
+  const inputSrc = readComponent("chat-input.tsx");
+  const panelSrc = readComponent("chat-panel.tsx");
+
+  describe("chat-header.tsx cleanup", () => {
+    it("should NOT contain History or Trash2 icon imports", () => {
+      // These icons moved to chat-input
+      expect(headerSrc).not.toMatch(/\bHistory\b.*from\s+["']lucide-react/);
+      expect(headerSrc).not.toMatch(/\bTrash2\b.*from\s+["']lucide-react/);
+    });
+
+    it("should NOT contain onClearMessages or onOpenTopicHistory props", () => {
+      expect(headerSrc).not.toContain("onClearMessages");
+      expect(headerSrc).not.toContain("onOpenTopicHistory");
+    });
+
+    it("should NOT contain formatAgentStatus function", () => {
+      expect(headerSrc).not.toContain("function formatAgentStatus");
+    });
+
+    it("should NOT render sessionType badge", () => {
+      // The header used to have {sessionType} — now removed
+      expect(headerSrc).not.toMatch(/\bsessionType\b/);
+    });
+
+    it("should NOT import getTopicCount", () => {
+      expect(headerSrc).not.toContain("getTopicCount");
+    });
+
+    it("should still contain agent avatar and session tabs", () => {
+      expect(headerSrc).toContain("AgentAvatar");
+      expect(headerSrc).toContain("renderTab");
+    });
+  });
+
+  describe("chat-input.tsx additions", () => {
+    it("should import History and Trash2 icons", () => {
+      expect(inputSrc).toContain("History");
+      expect(inputSrc).toContain("Trash2");
+    });
+
+    it("should import AgentStatus type", () => {
+      expect(inputSrc).toMatch(/import.*AgentStatus.*from/);
+    });
+
+    it("should contain formatAgentStatus function", () => {
+      expect(inputSrc).toContain("function formatAgentStatus");
+    });
+
+    it("should accept sessionType prop", () => {
+      expect(inputSrc).toContain("sessionType?:");
+    });
+
+    it("should accept topicCount prop", () => {
+      expect(inputSrc).toContain("topicCount?:");
+    });
+
+    it("should accept agentStatus prop", () => {
+      expect(inputSrc).toContain("agentStatus?:");
+    });
+
+    it("should accept onOpenTopicHistory prop", () => {
+      expect(inputSrc).toContain("onOpenTopicHistory?:");
+    });
+
+    it("should accept onClearMessages prop", () => {
+      expect(inputSrc).toContain("onClearMessages?:");
+    });
+
+    it("should render session meta section with separator", () => {
+      // The pipe separator between token info and session meta
+      expect(inputSrc).toContain("{/* Session meta — moved from header */}");
+    });
+
+    it("should render sessionType badge", () => {
+      expect(inputSrc).toContain("{sessionType}");
+      expect(inputSrc).toContain("uppercase");
+    });
+
+    it("should render topic count button with History icon", () => {
+      expect(inputSrc).toMatch(/대화 이력 보기/);
+      expect(inputSrc).toMatch(/<History\s+size=/);
+    });
+
+    it("should render clear messages button with Trash2 icon", () => {
+      expect(inputSrc).toMatch(/채팅 비우기/);
+      expect(inputSrc).toMatch(/<Trash2\s+size=/);
+    });
+
+    it("should render agent status indicator with animated dot", () => {
+      expect(inputSrc).toMatch(/animate-ping/);
+      expect(inputSrc).toMatch(/statusInfo\.dotColor/);
+    });
+
+    it("should use flex-wrap for responsive overflow prevention", () => {
+      expect(inputSrc).toContain("flex-wrap");
+    });
+  });
+
+  describe("chat-panel.tsx props wiring", () => {
+    it("should pass sessionType to ChatInput", () => {
+      expect(panelSrc).toMatch(/sessionType=\{sessionType/);
+    });
+
+    it("should pass topicCount to ChatInput", () => {
+      expect(panelSrc).toMatch(/topicCount=\{topicCount\}/);
+    });
+
+    it("should pass agentStatus to ChatInput", () => {
+      expect(panelSrc).toMatch(/agentStatus=\{agentStatus\}/);
+    });
+
+    it("should pass onOpenTopicHistory to ChatInput", () => {
+      // The ChatInput JSX should contain onOpenTopicHistory prop
+      const inputJSX = panelSrc.match(/<ChatInput[\s\S]*?\/>/)?.[0] || "";
+      expect(inputJSX).toContain("onOpenTopicHistory");
+      expect(inputJSX).toContain("setTopicHistoryOpen");
+    });
+
+    it("should pass onClearMessages to ChatInput", () => {
+      const inputJSX = panelSrc.match(/<ChatInput[\s\S]*?\/>/)?.[0] || "";
+      expect(inputJSX).toContain("onClearMessages");
+      expect(inputJSX).toContain("clearMessages");
+    });
+
+    it("should NOT pass onOpenTopicHistory to ChatHeader", () => {
+      const headerJSX = panelSrc.match(/<ChatHeader[\s\S]*?\/>/)?.[0] || "";
+      expect(headerJSX).not.toContain("onOpenTopicHistory");
+    });
+
+    it("should NOT pass onClearMessages to ChatHeader", () => {
+      const headerJSX = panelSrc.match(/<ChatHeader[\s\S]*?\/>/)?.[0] || "";
+      expect(headerJSX).not.toContain("onClearMessages");
+    });
+
+    it("should import getTopicCount for topic count state", () => {
+      expect(panelSrc).toContain("getTopicCount");
+    });
+  });
+
+  describe("formatAgentStatus in chat-input", () => {
+    // Extract and test the function logic
+    it("should return null for idle phase", () => {
+      // Verified via source inspection
+      expect(inputSrc).toContain('status.phase === "idle"');
+    });
+
+    it("should handle thinking, writing, tool, waiting phases", () => {
+      expect(inputSrc).toContain('"thinking"');
+      expect(inputSrc).toContain('"writing"');
+      expect(inputSrc).toContain('"tool"');
+      expect(inputSrc).toContain('"waiting"');
+    });
+  });
+});

--- a/apps/web/src/components/chat/chat-header.tsx
+++ b/apps/web/src/components/chat/chat-header.tsx
@@ -2,7 +2,7 @@
 import { useMemo, useRef, useEffect, useState, useCallback } from "react";
 import {
   MessageSquare, Plus, X, Pin, Zap,
-  MessageCircle, Bot, Settings, History, Trash2,
+  MessageCircle, Bot, Settings,
 } from "lucide-react";
 import { parseSessionKey, isTopicClosed, getCleanLabel } from "@/lib/gateway/session-utils";
 import { isSessionHidden, hideSession } from "@/lib/gateway/hidden-sessions";
@@ -10,7 +10,7 @@ import type { Agent, Session } from "@/lib/gateway/protocol";
 import type { AgentStatus } from "@/lib/gateway/hooks";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
 import { cn } from "@/lib/utils";
-import { getTopicCount } from "@/lib/gateway/topic-store";
+
 
 // --- Types ---
 
@@ -30,8 +30,6 @@ interface ChatHeaderProps {
   onHideSession?: (key: string) => void;
   onRenameSession?: (key: string, label: string) => void;
   onOpenSessionManager?: () => void;
-  onOpenTopicHistory?: () => void;
-  onClearMessages?: () => void;
 }
 
 // --- Constants ---
@@ -131,23 +129,6 @@ function deriveTopic(
 
 // --- Main Component ---
 
-/** Format agent status for display */
-function formatAgentStatus(status?: AgentStatus): { text: string; dotColor: string } | null {
-  if (!status || status.phase === "idle") return null;
-  switch (status.phase) {
-    case "thinking":
-      return { text: "생각 중…", dotColor: "bg-yellow-400" };
-    case "writing":
-      return { text: "작성 중…", dotColor: "bg-green-400" };
-    case "tool":
-      return { text: `${status.toolName}`, dotColor: "bg-blue-400" };
-    case "waiting":
-      return { text: "응답 대기 중", dotColor: "bg-zinc-500" };
-    default:
-      return null;
-  }
-}
-
 export function ChatHeader({
   sessionKey,
   agents,
@@ -160,20 +141,10 @@ export function ChatHeader({
   onHideSession,
   onRenameSession,
   onOpenSessionManager,
-  onOpenTopicHistory,
-  onClearMessages,
 }: ChatHeaderProps) {
   const [confirmDeleteKey, setConfirmDeleteKey] = useState<string | null>(null);
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editLabel, setEditLabel] = useState("");
-  const [topicCount, setTopicCount] = useState(0);
-  
-
-  // Load topic count for current session key
-  useEffect(() => {
-    if (!sessionKey) { setTopicCount(0); return; }
-    getTopicCount(sessionKey).then(setTopicCount).catch(() => setTopicCount(0));
-  }, [sessionKey]);
 
   const parsed = sessionKey ? parseSessionKey(sessionKey) : null;
   const agent = parsed ? agents.find((a) => a.id === parsed.agentId) : undefined;
@@ -210,8 +181,6 @@ export function ChatHeader({
 
   // Show all sessions (no active/idle split)
   const activeSessions = allAgentSessions;
-
-  const sessionType = !parsed ? "" : parsed.type === "main" ? "Main" : parsed.type === "thread" ? "Thread" : parsed.type === "subagent" ? "Sub-agent" : parsed.type === "cron" ? "Cron" : parsed.type === "a2a" ? "A2A" : "";
 
   const topic = useMemo(() => deriveTopic(session, messages), [session, messages]);
 
@@ -364,56 +333,11 @@ export function ChatHeader({
             <Settings size={12} />
           </button>
         )}
-        <span className="rounded-md bg-zinc-800 px-2 py-0.5 text-[10px] font-medium text-zinc-500 uppercase tracking-wide">
-          {sessionType}
-        </span>
         {session && isTopicClosed({ label: session.label as string | undefined }) && (
           <span className="rounded-md bg-red-900/30 border border-red-700/40 px-2 py-0.5 text-[10px] font-medium text-red-400">
             닫힘
           </span>
         )}
-        {topicCount > 1 && onOpenTopicHistory && (
-          <button
-            onClick={onOpenTopicHistory}
-            className="flex items-center gap-1 rounded-md bg-amber-900/20 border border-amber-600/20 px-2 py-0.5 text-[10px] font-medium text-amber-500 hover:bg-amber-900/40 hover:border-amber-500/40 transition"
-            title="대화 이력 보기 (리셋 기록)"
-          >
-            <History size={10} />
-            <span>대화 {topicCount}</span>
-          </button>
-        )}
-        {onClearMessages && (
-          <button
-            onClick={onClearMessages}
-            className="flex items-center gap-1 rounded-md bg-zinc-800/50 border border-zinc-700/30 px-1.5 py-0.5 text-[10px] font-medium text-zinc-400 hover:bg-red-900/30 hover:border-red-500/30 hover:text-red-400 transition"
-            title="채팅 비우기"
-          >
-            <Trash2 size={10} />
-          </button>
-        )}
-        {(() => {
-          const status = formatAgentStatus(agentStatus);
-          if (!status) return null;
-          const isAnimating = agentStatus?.phase !== "waiting";
-          return (
-            <span className="flex items-center gap-1.5 ml-1">
-              <span className="relative flex h-2 w-2">
-                {isAnimating && (
-                  <span className={cn("absolute inline-flex h-full w-full animate-ping rounded-full opacity-75", status.dotColor)} />
-                )}
-                <span className={cn("relative inline-flex h-2 w-2 rounded-full", status.dotColor)} />
-              </span>
-              <span className={cn(
-                "text-[11px] font-medium",
-                agentStatus?.phase === "waiting" ? "text-zinc-500" : "text-zinc-300"
-              )}>
-                {status.text}
-              </span>
-            </span>
-          );
-        })()}
-
-
       </div>
 
       {/* Session tabs */}

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -1,7 +1,7 @@
 
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { ArrowUp, Paperclip, Square, X, Reply } from "lucide-react";
+import { ArrowUp, Paperclip, Square, X, Reply, History, Trash2 } from "lucide-react";
 
 import { cn, windowStoragePrefix } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -14,7 +14,24 @@ import { SkillPicker, BUILTIN_COMMANDS } from "./skill-picker";
 import { useSkills } from "@/lib/gateway/use-skills";
 import { useKeyboardHeight } from "@/lib/hooks/use-keyboard-height";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
-import type { ReplyTo } from "@/lib/gateway/hooks";
+import type { ReplyTo, AgentStatus } from "@/lib/gateway/hooks";
+
+/** Format agent status for display */
+function formatAgentStatus(status?: AgentStatus): { text: string; dotColor: string } | null {
+  if (!status || status.phase === "idle") return null;
+  switch (status.phase) {
+    case "thinking":
+      return { text: "생각 중…", dotColor: "bg-yellow-400" };
+    case "writing":
+      return { text: "작성 중…", dotColor: "bg-green-400" };
+    case "tool":
+      return { text: `${status.toolName}`, dotColor: "bg-blue-400" };
+    case "waiting":
+      return { text: "응답 대기 중", dotColor: "bg-zinc-500" };
+    default:
+      return null;
+  }
+}
 
 export function ChatInput({
   onSend,
@@ -33,6 +50,11 @@ export function ChatInput({
   tokenPercent,
   replyingTo,
   onClearReply,
+  sessionType,
+  topicCount,
+  agentStatus,
+  onOpenTopicHistory,
+  onClearMessages,
 }: {
   onSend: (text: string) => void;
   onAbort: () => void;
@@ -58,6 +80,16 @@ export function ChatInput({
   replyingTo?: ReplyTo | null;
   /** Clear reply target */
   onClearReply?: () => void;
+  /** Session type label (e.g. "Main", "Thread") */
+  sessionType?: string;
+  /** Number of topics for topic history button */
+  topicCount?: number;
+  /** Agent status for writing/thinking indicator */
+  agentStatus?: AgentStatus;
+  /** Callback to open topic history */
+  onOpenTopicHistory?: () => void;
+  /** Callback to clear messages */
+  onClearMessages?: () => void;
 }) {
   const keyboardHeight = useKeyboardHeight();
   const isMobile = useIsMobile();
@@ -347,13 +379,14 @@ export function ChatInput({
             </div>
           )}
 
-          {/* Model & token info bar */}
-          {(model || tokenStr) && (() => {
+          {/* Model & token info bar + session meta */}
+          {(model || tokenStr || sessionType || topicCount || agentStatus) && (() => {
             const isCritical = tokenPercent != null && tokenPercent >= 90;
             const isWarning = tokenPercent != null && tokenPercent >= 70;
+            const statusInfo = formatAgentStatus(agentStatus);
             return (
               <div className={cn(
-                "flex items-center gap-2.5 px-3 pt-2 pb-0.5 text-xs tabular-nums tracking-tight",
+                "flex flex-wrap items-center gap-x-2.5 gap-y-1 px-3 pt-2 pb-0.5 text-xs tabular-nums tracking-tight",
                 isCritical
                   ? "text-red-400"
                   : isWarning
@@ -384,6 +417,60 @@ export function ChatInput({
                   <span className="ml-1 text-[11px] font-medium text-amber-400/80">
                     ⚡ 토큰 사용량 높음
                   </span>
+                )}
+
+                {/* Session meta — moved from header */}
+                {(sessionType || (topicCount && topicCount > 1) || onClearMessages || statusInfo) && (
+                  <>
+                    <span className="text-zinc-700">|</span>
+
+                    {sessionType && (
+                      <span className="rounded-md bg-zinc-800 px-1.5 py-0.5 text-[10px] font-medium text-zinc-500 uppercase tracking-wide">
+                        {sessionType}
+                      </span>
+                    )}
+
+                    {topicCount != null && topicCount > 1 && onOpenTopicHistory && (
+                      <button
+                        onClick={onOpenTopicHistory}
+                        className="flex items-center gap-1 rounded-md bg-amber-900/20 border border-amber-600/20 px-1.5 py-0.5 text-[10px] font-medium text-amber-500 hover:bg-amber-900/40 hover:border-amber-500/40 transition"
+                        title="대화 이력 보기 (리셋 기록)"
+                      >
+                        <History size={10} />
+                        <span>대화 {topicCount}</span>
+                      </button>
+                    )}
+
+                    {onClearMessages && (
+                      <button
+                        onClick={onClearMessages}
+                        className="flex items-center gap-1 rounded-md bg-zinc-800/50 border border-zinc-700/30 px-1 py-0.5 text-[10px] font-medium text-zinc-400 hover:bg-red-900/30 hover:border-red-500/30 hover:text-red-400 transition"
+                        title="채팅 비우기"
+                      >
+                        <Trash2 size={10} />
+                      </button>
+                    )}
+
+                    {statusInfo && (() => {
+                      const isAnimating = agentStatus?.phase !== "waiting";
+                      return (
+                        <span className="flex items-center gap-1.5">
+                          <span className="relative flex h-2 w-2">
+                            {isAnimating && (
+                              <span className={cn("absolute inline-flex h-full w-full animate-ping rounded-full opacity-75", statusInfo.dotColor)} />
+                            )}
+                            <span className={cn("relative inline-flex h-2 w-2 rounded-full", statusInfo.dotColor)} />
+                          </span>
+                          <span className={cn(
+                            "text-[11px] font-medium",
+                            agentStatus?.phase === "waiting" ? "text-zinc-500" : "text-zinc-300"
+                          )}>
+                            {statusInfo.text}
+                          </span>
+                        </span>
+                      );
+                    })()}
+                  </>
                 )}
               </div>
             );

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -9,6 +9,7 @@ import { SessionSwitcher } from "./session-switcher";
 import { AgentBrowser } from "./agent-browser";
 import { DropZone, useFileAttachments, attachmentToPayload } from "./file-attachments";
 import { parseSessionKey, sessionDisplayName, type GatewaySession, isTopicClosed, isTopicSession, CLOSED_PREFIX, getCleanLabel } from "@/lib/gateway/session-utils";
+import { getTopicCount } from "@/lib/gateway/topic-store";
 import { isSessionHidden, hideSession, unhideSession, getHiddenSessions } from "@/lib/gateway/hidden-sessions";
 import { TaskMemo } from "./task-memo";
 import { SessionSettings } from "@/components/settings/session-settings";
@@ -740,6 +741,16 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
         : `${tokenCount}`
     : null;
 
+  // Session type label for input bar meta
+  const sessionType = !parsedSession ? "" : parsedSession.type === "main" ? "Main" : parsedSession.type === "thread" ? "Thread" : parsedSession.type === "subagent" ? "Sub-agent" : parsedSession.type === "cron" ? "Cron" : parsedSession.type === "a2a" ? "A2A" : "";
+
+  // Topic count for input bar meta
+  const [topicCount, setTopicCount] = useState(0);
+  useEffect(() => {
+    if (!effectiveSessionKey) { setTopicCount(0); return; }
+    getTopicCount(effectiveSessionKey).then(setTopicCount).catch(() => setTopicCount(0));
+  }, [effectiveSessionKey]);
+
   return (
     <div
       ref={panelRef}
@@ -762,12 +773,6 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
           onHideSession={handleHide}
           onRenameSession={(key, label) => handleRename(key, label)}
           onOpenSessionManager={() => setSessionManagerOpen(true)}
-          onOpenTopicHistory={() => setTopicHistoryOpen(true)}
-          onClearMessages={() => {
-            if (window.confirm("채팅 내용을 모두 비우시겠습니까?")) {
-              clearMessages();
-            }
-          }}
         />
       )}
 
@@ -812,6 +817,15 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
         tokenPercent={(currentSession as any)?.percentUsed as number | undefined}
         replyingTo={replyingTo}
         onClearReply={clearReplyTo}
+        sessionType={sessionType || undefined}
+        topicCount={topicCount}
+        agentStatus={agentStatus}
+        onOpenTopicHistory={() => setTopicHistoryOpen(true)}
+        onClearMessages={() => {
+          if (window.confirm("채팅 내용을 모두 비우시겠습니까?")) {
+            clearMessages();
+          }
+        }}
       />
 
       {/* Topic Name Dialog */}


### PR DESCRIPTION
## 변경 요약
상단 헤더의 세션 메타 정보(MAIN 배지, 대화 수, 삭제, 작성 중)를 채팅 입력 박스 영역으로 이동

- chat-header.tsx: 메타 정보 제거
- chat-input.tsx: 메타 정보 추가 + 모바일 반응형
- chat-panel.tsx: props 연결
- 30개 테스트

Closes #171