### PR TITLE
feat: show current time in chat input bar (#174)

### DIFF
--- a/apps/web/src/__tests__/chat-clock.test.tsx
+++ b/apps/web/src/__tests__/chat-clock.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for #174: Current time display in chat input bar
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { ChatInput } from "@/components/chat/chat-input";
+
+// Mock framer-motion to avoid animation issues in tests
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  },
+}));
+
+// Mock hooks used by ChatInput
+vi.mock("@/lib/hooks/use-keyboard-height", () => ({
+  useKeyboardHeight: () => 0,
+}));
+vi.mock("@/lib/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+vi.mock("@/lib/gateway/use-skills", () => ({
+  useSkills: () => ({ skills: [] }),
+}));
+vi.mock("@/hooks/use-autosize-textarea", () => ({
+  useAutosizeTextArea: () => {},
+}));
+
+describe("#174: Clock display in chat input", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders current time in HH:MM format", () => {
+    vi.setSystemTime(new Date(2026, 2, 7, 16, 19, 0));
+
+    render(
+      <ChatInput
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        streaming={false}
+        disabled={false}
+        model="claude-sonnet-4-20250514"
+        tokenStr="10k"
+      />
+    );
+
+    const clock = screen.getByTestId("chat-clock");
+    expect(clock).toBeDefined();
+    expect(clock.textContent).toBe("16:19");
+  });
+
+  it("pads hours and minutes with leading zeros", () => {
+    vi.setSystemTime(new Date(2026, 0, 1, 3, 5, 0));
+
+    render(
+      <ChatInput
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        streaming={false}
+        disabled={false}
+        model="test-model"
+        tokenStr="1k"
+      />
+    );
+
+    const clock = screen.getByTestId("chat-clock");
+    expect(clock.textContent).toBe("03:05");
+  });
+
+  it("updates time when minute changes", () => {
+    vi.setSystemTime(new Date(2026, 2, 7, 14, 30, 0, 0));
+
+    render(
+      <ChatInput
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        streaming={false}
+        disabled={false}
+        model="test-model"
+        tokenStr="1k"
+      />
+    );
+
+    const clock = screen.getByTestId("chat-clock");
+    expect(clock.textContent).toBe("14:30");
+
+    // Advance to next minute boundary (60s)
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(clock.textContent).toBe("14:31");
+  });
+});

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -289,6 +289,30 @@ export function ChatInput({
     return () => document.removeEventListener("focus-chat-input", handler);
   }, []);
 
+  // Clock: update every minute
+  const [clockTime, setClockTime] = useState(() => {
+    const now = new Date();
+    return `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+  });
+  useEffect(() => {
+    const tick = () => {
+      const now = new Date();
+      setClockTime(`${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`);
+    };
+    // Align to next minute boundary
+    const msUntilNextMinute = (60 - new Date().getSeconds()) * 1000 - new Date().getMilliseconds();
+    const alignTimeout = setTimeout(() => {
+      tick();
+      // Then tick every 60s
+      intervalRef.current = setInterval(tick, 60_000);
+    }, msUntilNextMinute);
+    const intervalRef: { current: ReturnType<typeof setInterval> | null } = { current: null };
+    return () => {
+      clearTimeout(alignTimeout);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
   const showAttachments = onRemoveAttachment && attachments.length > 0;
 
   return (
@@ -375,6 +399,8 @@ export function ChatInput({
                     <span className="font-semibold">{tokenPercent}%</span>
                   </>
                 )}
+                <span className="text-zinc-700">·</span>
+                <span data-testid="chat-clock">{clockTime}</span>
                 {isCritical && (
                   <span className="ml-1 text-[11px] font-medium text-red-400/90">
                     ⚠️ 컨텍스트 한도 임박 — <code className="rounded bg-red-400/10 px-1 py-0.5 text-[10px]">/new</code> 또는 <code className="rounded bg-red-400/10 px-1 py-0.5 text-[10px]">/compact</code> 권장


### PR DESCRIPTION
## 변경 요약
채팅 입력 박스에 현재 시간(HH:MM) 실시간 표시

- 분 경계 정렬 + 60초 interval
- 모델/토큰 info bar에 · HH:MM 형식
- 3개 테스트

Closes #174