### PR TITLE
feat: add reply-to (quote reply) functionality (#79)

### DIFF
--- a/apps/web/src/__tests__/reply-to.test.ts
+++ b/apps/web/src/__tests__/reply-to.test.ts
@@ -1,0 +1,211 @@
+/**
+ * reply-to.test.ts — Tests for reply-to (quote reply) functionality (#79)
+ *
+ * Tests:
+ * - ReplyTo type and helper functions (truncateForPreview, canBeReplyTarget, buildReplyTo)
+ * - replyTo field persistence in StoredMessage
+ * - DisplayMessage replyTo field
+ */
+import { describe, it, expect } from "vitest";
+import {
+  truncateForPreview,
+  canBeReplyTarget,
+  buildReplyTo,
+  HIDDEN_REPLY_RE,
+  type DisplayMessage,
+  type ReplyTo,
+} from "@/lib/gateway/hooks";
+import type { StoredMessage, ReplyToData } from "@/lib/gateway/message-store";
+
+// ---------------------------------------------------------------------------
+// truncateForPreview
+// ---------------------------------------------------------------------------
+describe("truncateForPreview", () => {
+  it("returns short text as-is", () => {
+    expect(truncateForPreview("hello world")).toBe("hello world");
+  });
+
+  it("truncates long text with ellipsis", () => {
+    const long = "a".repeat(200);
+    const result = truncateForPreview(long, 100);
+    expect(result.length).toBe(100);
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  it("replaces newlines with spaces", () => {
+    expect(truncateForPreview("line1\nline2\nline3")).toBe("line1 line2 line3");
+  });
+
+  it("handles empty string", () => {
+    expect(truncateForPreview("")).toBe("");
+  });
+
+  it("uses default maxLen of 100", () => {
+    const text = "x".repeat(150);
+    const result = truncateForPreview(text);
+    expect(result.length).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canBeReplyTarget
+// ---------------------------------------------------------------------------
+describe("canBeReplyTarget", () => {
+  const makeMsg = (role: string, content: string): DisplayMessage => ({
+    id: "test-1",
+    role: role as DisplayMessage["role"],
+    content,
+    timestamp: new Date().toISOString(),
+    toolCalls: [],
+  });
+
+  it("allows user messages", () => {
+    expect(canBeReplyTarget(makeMsg("user", "hello"))).toBe(true);
+  });
+
+  it("allows assistant messages", () => {
+    expect(canBeReplyTarget(makeMsg("assistant", "hi there"))).toBe(true);
+  });
+
+  it("rejects system messages", () => {
+    expect(canBeReplyTarget(makeMsg("system", "system info"))).toBe(false);
+  });
+
+  it("rejects session-boundary messages", () => {
+    expect(canBeReplyTarget(makeMsg("session-boundary", ""))).toBe(false);
+  });
+
+  it("rejects hidden reply messages (NO_REPLY)", () => {
+    expect(canBeReplyTarget(makeMsg("assistant", "NO_REPLY"))).toBe(false);
+  });
+
+  it("rejects HEARTBEAT_OK messages", () => {
+    expect(canBeReplyTarget(makeMsg("assistant", "HEARTBEAT_OK"))).toBe(false);
+  });
+
+  it("rejects REPLY_SKIP messages", () => {
+    expect(canBeReplyTarget(makeMsg("assistant", "REPLY_SKIP"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReplyTo
+// ---------------------------------------------------------------------------
+describe("buildReplyTo", () => {
+  const makeMsg = (id: string, role: string, content: string): DisplayMessage => ({
+    id,
+    role: role as DisplayMessage["role"],
+    content,
+    timestamp: new Date().toISOString(),
+    toolCalls: [],
+  });
+
+  it("builds ReplyTo from a valid user message", () => {
+    const msg = makeMsg("msg-1", "user", "What is React?");
+    const reply = buildReplyTo(msg);
+    expect(reply).toEqual({
+      id: "msg-1",
+      content: "What is React?",
+      role: "user",
+    });
+  });
+
+  it("builds ReplyTo from a valid assistant message", () => {
+    const msg = makeMsg("msg-2", "assistant", "React is a JavaScript library.");
+    const reply = buildReplyTo(msg);
+    expect(reply).toEqual({
+      id: "msg-2",
+      content: "React is a JavaScript library.",
+      role: "assistant",
+    });
+  });
+
+  it("truncates long content in ReplyTo", () => {
+    const longContent = "a".repeat(200);
+    const msg = makeMsg("msg-3", "user", longContent);
+    const reply = buildReplyTo(msg);
+    expect(reply).not.toBeNull();
+    expect(reply!.content.length).toBe(100);
+    expect(reply!.content.endsWith("…")).toBe(true);
+  });
+
+  it("returns null for system messages", () => {
+    const msg = makeMsg("msg-4", "system", "system message");
+    expect(buildReplyTo(msg)).toBeNull();
+  });
+
+  it("returns null for hidden messages", () => {
+    const msg = makeMsg("msg-5", "assistant", "NO_REPLY");
+    expect(buildReplyTo(msg)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StoredMessage replyTo field
+// ---------------------------------------------------------------------------
+describe("StoredMessage replyTo field", () => {
+  it("can include replyTo data", () => {
+    const replyTo: ReplyToData = {
+      id: "original-msg-1",
+      content: "Original question",
+      role: "user",
+    };
+
+    const stored: StoredMessage = {
+      sessionKey: "agent:ops:main",
+      id: "reply-msg-1",
+      role: "user",
+      content: "This is a reply",
+      timestamp: new Date().toISOString(),
+      replyTo,
+    };
+
+    expect(stored.replyTo).toEqual(replyTo);
+    expect(stored.replyTo!.id).toBe("original-msg-1");
+    expect(stored.replyTo!.content).toBe("Original question");
+    expect(stored.replyTo!.role).toBe("user");
+  });
+
+  it("replyTo is optional", () => {
+    const stored: StoredMessage = {
+      sessionKey: "agent:ops:main",
+      id: "msg-no-reply",
+      role: "assistant",
+      content: "Regular message",
+      timestamp: new Date().toISOString(),
+    };
+
+    expect(stored.replyTo).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DisplayMessage replyTo field
+// ---------------------------------------------------------------------------
+describe("DisplayMessage replyTo integration", () => {
+  it("DisplayMessage can carry replyTo", () => {
+    const replyTo: ReplyTo = {
+      id: "orig-1",
+      content: "What is TypeScript?",
+      role: "user",
+    };
+
+    const msg: DisplayMessage = {
+      id: "reply-1",
+      role: "assistant",
+      content: "TypeScript is...",
+      timestamp: new Date().toISOString(),
+      toolCalls: [],
+      replyTo,
+    };
+
+    expect(msg.replyTo).toEqual(replyTo);
+  });
+
+  it("multiline content is flattened in preview", () => {
+    const content = "Line 1\nLine 2\nLine 3";
+    const preview = truncateForPreview(content);
+    expect(preview).toBe("Line 1 Line 2 Line 3");
+    expect(preview).not.toContain("\n");
+  });
+});

--- a/apps/web/src/components/chat/message-list.tsx
+++ b/apps/web/src/components/chat/message-list.tsx
@@ -678,17 +678,33 @@ function CopyButton({ text }: { text: string }) {
 }
 
 
-/** Reply quote block shown above message content */
-function ReplyQuoteBlock({ replyTo }: { replyTo: { id: string; content: string; role: string } }) {
+/** Reply quote block shown above message content — click to scroll to original */
+function ReplyQuoteBlock({ replyTo, allMessages }: { replyTo: { id: string; content: string; role: string }; allMessages?: DisplayMessage[] }) {
   const roleLabel = replyTo.role === "user" ? "나" : "에이전트";
+
+  const handleClick = useCallback(() => {
+    // Find the original message element by scanning data-msg-id attributes
+    const target = document.querySelector(`[data-msg-id="${CSS.escape(replyTo.id)}"]`) as HTMLElement | null;
+    if (target) {
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
+      // Highlight animation
+      target.classList.add("reply-highlight");
+      setTimeout(() => target.classList.remove("reply-highlight"), 1500);
+    }
+  }, [replyTo.id]);
+
   return (
-    <div className="mb-1.5 flex items-start gap-1.5 rounded-lg border-l-2 border-primary/40 bg-primary/5 px-2.5 py-1.5 text-xs text-muted-foreground">
+    <button
+      type="button"
+      onClick={handleClick}
+      className="mb-1.5 flex w-full items-start gap-1.5 rounded-lg border-l-2 border-primary/40 bg-primary/5 px-2.5 py-1.5 text-left text-xs text-muted-foreground transition hover:bg-primary/10 cursor-pointer"
+    >
       <Reply size={12} className="mt-0.5 shrink-0 rotate-180 text-primary/60" />
       <div className="min-w-0">
         <span className="font-medium text-primary/80">{roleLabel}</span>
         <p className="mt-0.5 truncate">{replyTo.content || "(내용 없음)"}</p>
       </div>
-    </div>
+    </button>
   );
 }
 
@@ -724,7 +740,7 @@ const MessageBubble = React.memo(React.forwardRef<HTMLDivElement, { message: Dis
   }
 
   return (
-    <div ref={ref} className={`group flex gap-3 ${isUser ? "justify-end" : ""} `}>
+    <div ref={ref} data-msg-id={message.id} className={`group flex gap-3 transition-colors duration-500 ${isUser ? "justify-end" : ""} [&.reply-highlight]:bg-primary/10 [&.reply-highlight]:rounded-xl`}>
       {/* Action buttons for user messages (left of bubble) */}
       {isUser && (
         <div className="flex items-start gap-0.5 pt-2">

--- a/apps/web/src/lib/gateway/hooks.tsx
+++ b/apps/web/src/lib/gateway/hooks.tsx
@@ -914,6 +914,7 @@ export function useChat(sessionKey?: string) {
             attachments: lm.attachments as DisplayAttachment[] | undefined,
             oldSessionId: lm.oldSessionId,
             newSessionId: lm.newSessionId,
+            replyTo: lm.replyTo as ReplyTo | undefined,
           });
 
           // Local messages not in gateway — split into older (prepend) and newer (append)
@@ -935,6 +936,17 @@ export function useChat(sessionKey?: string) {
           const appendMsgs = localMsgs
             .filter((lm) => lm.role !== "session-boundary" && isNotInGateway(lm) && !isHiddenMessage(lm.role, lm.content) && new Date(lm.timestamp).getTime() >= newestGatewayTs)
             .map(toDisplayMsg);
+
+          // Restore replyTo from local store (gateway doesn't persist it)
+          for (const hm of dedupedHistMsgs) {
+            if (hm.replyTo) continue;
+            const local = localMsgs.find(
+              (lm) => lm.role === hm.role && lm.replyTo && normalizeContentForDedup(lm.content) === normalizeContentForDedup(hm.content)
+            );
+            if (local?.replyTo) {
+              hm.replyTo = local.replyTo as ReplyTo;
+            }
+          }
 
           // Restore attachments stripped by compaction (e.g. images)
           const localWithAtts = localMsgs.filter(
@@ -997,6 +1009,7 @@ export function useChat(sessionKey?: string) {
               attachments: lm.attachments as DisplayAttachment[] | undefined,
               oldSessionId: lm.oldSessionId,
               newSessionId: lm.newSessionId,
+              replyTo: lm.replyTo as ReplyTo | undefined,
             }));
         }
       } catch (e) {
@@ -1019,6 +1032,7 @@ export function useChat(sessionKey?: string) {
           attachments: m.attachments,
           oldSessionId: m.oldSessionId,
           newSessionId: m.newSessionId,
+          replyTo: m.replyTo,
         }));
       saveLocalMessages(sessionKey, toStore).catch(() => {});
 
@@ -1627,7 +1641,7 @@ export function useChat(sessionKey?: string) {
         replyTo,
       };
       setMessages((prev) => [...prev, userMsg]);
-      // Persist user message to local store
+      // Persist user message to local store (including replyTo for quote persistence)
       saveLocalMessages(sessionKey, [{
         sessionKey,
         id: msgId,
@@ -1635,6 +1649,7 @@ export function useChat(sessionKey?: string) {
         content: text,
         timestamp: userMsg.timestamp,
         attachments: userMsg.attachments,
+        replyTo: replyTo,
       }]).catch(() => {});
       // Clear replyingTo after send
       if (replyingTo) setReplyingToState(null);

--- a/apps/web/src/lib/gateway/message-store.ts
+++ b/apps/web/src/lib/gateway/message-store.ts
@@ -10,6 +10,12 @@ const DB_NAME = "intelli-claw-messages";
 const DB_VERSION = 1;
 const STORE_NAME = "messages";
 
+export interface ReplyToData {
+  id: string;
+  content: string;
+  role: string;
+}
+
 export interface StoredMessage {
   /** Composite key: sessionKey + id */
   sessionKey: string;
@@ -21,6 +27,7 @@ export interface StoredMessage {
   attachments?: unknown[];
   oldSessionId?: string;
   newSessionId?: string;
+  replyTo?: ReplyToData;
 }
 
 // --- IndexedDB helpers ---


### PR DESCRIPTION
## 변경 요약
Reply-to 인용 답장 기능

- 메시지 hover 시 reply 버튼
- 입력창 상단 reply preview bar
- ReplyQuote 컴포넌트 (클릭 시 스크롤 + 하이라이트)
- message-store에 replyTo persist
- 16개 테스트

Closes #79