### PR TITLE
feat: flush topic summary to memory on close (#150)

### DIFF
--- a/apps/web/src/__tests__/topic-summary.test.ts
+++ b/apps/web/src/__tests__/topic-summary.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { generateTopicSummary } from "@/lib/gateway/topic-summary";
+import type { StoredMessage } from "@/lib/gateway/message-store";
+
+function msg(role: StoredMessage["role"], content: string, ts?: string): StoredMessage {
+  return {
+    sessionKey: "agent:alpha:main:topic:test",
+    id: `msg-${Math.random().toString(36).slice(2, 8)}`,
+    role,
+    content,
+    timestamp: ts || new Date().toISOString(),
+  };
+}
+
+describe("generateTopicSummary", () => {
+  it("returns empty string for empty messages array", () => {
+    expect(generateTopicSummary([])).toBe("");
+  });
+
+  it("returns empty string when no user messages exist", () => {
+    const messages = [
+      msg("assistant", "Hello, how can I help?"),
+      msg("system", "Session started"),
+    ];
+    expect(generateTopicSummary(messages)).toBe("");
+  });
+
+  it("extracts summary from a single user message", () => {
+    const messages = [
+      msg("user", "React hooks 패턴에 대해 알려줘"),
+      msg("assistant", "React hooks는..."),
+    ];
+    const summary = generateTopicSummary(messages);
+    expect(summary).toBe("React hooks 패턴에 대해 알려줘");
+  });
+
+  it("joins multiple user messages with separator", () => {
+    const messages = [
+      msg("user", "첫 번째 질문"),
+      msg("assistant", "답변 1"),
+      msg("user", "두 번째 질문"),
+      msg("assistant", "답변 2"),
+    ];
+    const summary = generateTopicSummary(messages);
+    expect(summary).toBe("첫 번째 질문 · 두 번째 질문");
+  });
+
+  it("only takes last 5 user messages", () => {
+    const messages = [
+      msg("user", "질문 1"),
+      msg("user", "질문 2"),
+      msg("user", "질문 3"),
+      msg("user", "질문 4"),
+      msg("user", "질문 5"),
+      msg("user", "질문 6"),
+      msg("user", "질문 7"),
+    ];
+    const summary = generateTopicSummary(messages);
+    // Should only include last 5
+    expect(summary).not.toContain("질문 1");
+    expect(summary).not.toContain("질문 2");
+    expect(summary).toContain("질문 3");
+    expect(summary).toContain("질문 7");
+  });
+
+  it("truncates to max summary length", () => {
+    const messages = [
+      msg("user", "이것은 매우 긴 첫 번째 질문입니다 정말로 길게 작성합니다"),
+      msg("user", "이것은 매우 긴 두 번째 질문입니다 정말로 길게 작성합니다"),
+      msg("user", "이것은 매우 긴 세 번째 질문입니다 정말로 길게 작성합니다"),
+      msg("user", "이것은 매우 긴 네 번째 질문입니다 정말로 길게 작성합니다"),
+      msg("user", "이것은 매우 긴 다섯 번째 질문입니다 정말로 길게 작성합니다"),
+    ];
+    const summary = generateTopicSummary(messages);
+    expect(summary.length).toBeLessThanOrEqual(120);
+    expect(summary).toMatch(/…$/);
+  });
+
+  it("strips slash commands from user messages", () => {
+    const messages = [
+      msg("user", "/status"),
+      msg("user", "/model gpt-4o\n실제 질문입니다"),
+      msg("user", "일반 메시지"),
+    ];
+    const summary = generateTopicSummary(messages);
+    expect(summary).not.toContain("/status");
+    expect(summary).not.toContain("/model");
+    expect(summary).toContain("실제 질문입니다");
+    expect(summary).toContain("일반 메시지");
+  });
+
+  it("strips MEDIA: lines from user messages", () => {
+    const messages = [
+      msg("user", "이미지 첨부합니다\nMEDIA:/tmp/image.png"),
+    ];
+    const summary = generateTopicSummary(messages);
+    expect(summary).toBe("이미지 첨부합니다");
+    expect(summary).not.toContain("MEDIA:");
+  });
+
+  it("strips file attachment hints", () => {
+    const messages = [
+      msg("user", "📎 [PDF: doc.pdf] /tmp/doc.pdf\n이 문서 분석해줘"),
+    ];
+    const summary = generateTopicSummary(messages);
+    expect(summary).toContain("이 문서 분석해줘");
+    expect(summary).not.toContain("📎");
+  });
+
+  it("takes first sentence when multiple sentences exist", () => {
+    const messages = [
+      msg("user", "첫 번째 문장입니다. 두 번째 문장입니다. 세 번째도 있습니다."),
+    ];
+    const summary = generateTopicSummary(messages);
+    expect(summary).toBe("첫 번째 문장입니다.");
+  });
+
+  it("returns empty string when all user messages are slash commands only", () => {
+    const messages = [
+      msg("user", "/status"),
+      msg("user", "/clear"),
+      msg("user", "/help"),
+    ];
+    const summary = generateTopicSummary(messages);
+    expect(summary).toBe("");
+  });
+
+  it("handles messages with only whitespace content", () => {
+    const messages = [
+      msg("user", "   "),
+      msg("user", "\n\n"),
+    ];
+    const summary = generateTopicSummary(messages);
+    expect(summary).toBe("");
+  });
+
+  it("interleaves user and assistant messages correctly", () => {
+    const messages = [
+      msg("user", "질문 A"),
+      msg("assistant", "답변 A"),
+      msg("user", "질문 B"),
+      msg("assistant", "답변 B"),
+      msg("user", "질문 C"),
+    ];
+    const summary = generateTopicSummary(messages);
+    expect(summary).toBe("질문 A · 질문 B · 질문 C");
+  });
+});

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -11,6 +11,9 @@ import { DropZone, useFileAttachments, attachmentToPayload } from "./file-attach
 import { parseSessionKey, sessionDisplayName, type GatewaySession, isTopicClosed, isTopicSession, CLOSED_PREFIX, getCleanLabel } from "@/lib/gateway/session-utils";
 import { getTopicCount } from "@/lib/gateway/topic-store";
 import { isSessionHidden, hideSession, unhideSession, getHiddenSessions } from "@/lib/gateway/hidden-sessions";
+import { getLocalMessages } from "@/lib/gateway/message-store";
+import { generateTopicSummary } from "@/lib/gateway/topic-summary";
+import { markSessionEnded } from "@/lib/gateway/topic-store";
 
 import { SessionSettings } from "@/components/settings/session-settings";
 import { ChatHeader } from "./chat-header";
@@ -188,6 +191,20 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
         : currentLabel;
       try {
         await client.request("sessions.patch", { key, label: CLOSED_PREFIX + cleanLabel });
+
+        // Phase 3: flush topic summary to memory
+        try {
+          const localMessages = await getLocalMessages(key);
+          const summary = generateTopicSummary(localMessages);
+          const sessionId = session?.sessionId || key;
+          await markSessionEnded(key, sessionId, {
+            summary: summary || undefined,
+            messageCount: localMessages.length,
+          });
+        } catch (summaryErr) {
+          console.warn("[AWF] topic summary flush failed:", summaryErr);
+        }
+
         await refreshSessions();
       } catch (err) {
         console.error("[AWF] close topic error:", err);

--- a/apps/web/src/components/chat/session-switcher.tsx
+++ b/apps/web/src/components/chat/session-switcher.tsx
@@ -35,6 +35,7 @@ import {
   unhideSession,
   getHiddenSessions,
 } from "@/lib/gateway/hidden-sessions";
+import { getTopicHistory, type TopicEntry } from "@/lib/gateway/topic-store";
 import type { Session } from "@/lib/gateway/protocol";
 
 // ---- Type icon per session type ----
@@ -150,6 +151,7 @@ export function SessionSwitcher({
   const [editLabel, setEditLabel] = useState("");
   const [actionBusy, setActionBusy] = useState(false);
   const [visibleCount, setVisibleCount] = useState(40);
+  const [topicSummaries, setTopicSummaries] = useState<Record<string, string>>({});
 
   const searchRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -251,8 +253,25 @@ export function SessionSwitcher({
       setTimeout(() => searchRef.current?.focus(), 16);
       // warm up list after first paint
       setTimeout(() => setVisibleCount(120), 60);
+
+      // Load topic summaries for closed topics
+      (async () => {
+        const summaryMap: Record<string, string> = {};
+        for (const s of closedTopics) {
+          try {
+            const entries = await getTopicHistory(s.key);
+            const withSummary = entries.find((e: TopicEntry) => e.summary);
+            if (withSummary?.summary) {
+              summaryMap[s.key] = withSummary.summary;
+            }
+          } catch { /* ignore */ }
+        }
+        if (Object.keys(summaryMap).length > 0) {
+          setTopicSummaries(summaryMap);
+        }
+      })();
     }
-  }, [open]);
+  }, [open, closedTopics]);
 
   // Global Escape key listener (works even when palette div has no focus)
   useEffect(() => {
@@ -718,6 +737,7 @@ export function SessionSwitcher({
                   {closedTopics.map((session) => {
                     const parsed = parseSessionKey(session.key);
                     const cleanLabel = getCleanLabel(session) || sessionDisplayName(session);
+                    const summary = topicSummaries[session.key];
                     return (
                       <div
                         key={`closed-${session.key}`}
@@ -731,6 +751,11 @@ export function SessionSwitcher({
                               닫힘
                             </span>
                           </div>
+                          {summary && (
+                            <div className="mt-0.5 truncate text-xs text-muted-foreground/70 italic">
+                              {summary}
+                            </div>
+                          )}
                           {session.updatedAt && (
                             <div className="mt-0.5 text-xs text-muted-foreground flex items-center gap-0.5">
                               <Clock size={10} />

--- a/apps/web/src/lib/gateway/topic-summary.ts
+++ b/apps/web/src/lib/gateway/topic-summary.ts
@@ -1,0 +1,78 @@
+/**
+ * Topic Summary — pure client-side conversation summarizer.
+ *
+ * Extracts a short summary from user messages without LLM calls.
+ * Used when closing a topic to persist a memory snapshot.
+ */
+
+import type { StoredMessage } from "./message-store";
+
+/** Maximum number of recent user messages to consider */
+const MAX_USER_MESSAGES = 5;
+/** Maximum summary length in characters */
+const MAX_SUMMARY_LENGTH = 120;
+
+/**
+ * Generate a short summary from conversation messages.
+ *
+ * Strategy:
+ * 1. Take last N user messages
+ * 2. Extract key phrases (first sentence or first line of each)
+ * 3. Join and truncate
+ *
+ * No LLM calls — purely string-based extraction.
+ */
+export function generateTopicSummary(messages: StoredMessage[]): string {
+  // Filter to user messages only
+  const userMessages = messages.filter((m) => m.role === "user");
+
+  if (userMessages.length === 0) return "";
+
+  // Take last N user messages
+  const recent = userMessages.slice(-MAX_USER_MESSAGES);
+
+  // Extract first meaningful line from each message
+  const phrases = recent
+    .map((m) => extractKeyPhrase(m.content))
+    .filter(Boolean);
+
+  if (phrases.length === 0) return "";
+
+  // Join with separator and truncate
+  const joined = phrases.join(" · ");
+  if (joined.length <= MAX_SUMMARY_LENGTH) return joined;
+  return joined.slice(0, MAX_SUMMARY_LENGTH - 1) + "…";
+}
+
+/**
+ * Extract the key phrase from a message content.
+ * Takes the first sentence or first line, stripping commands and whitespace.
+ */
+function extractKeyPhrase(content: string): string {
+  if (!content) return "";
+
+  // Remove slash commands
+  let text = content.replace(/^\/(new|reset|status|help|reasoning|model\s+\S+|think\S*|verbose\S*|stop|clear)\b[^\n]*/gi, "").trim();
+
+  // Remove MEDIA: lines
+  text = text.replace(/^MEDIA:[^\n]*/gm, "").trim();
+
+  // Remove file attachment hints
+  text = text.replace(/^📎\s*\[.*?\]\s*[^\n]*/gm, "").trim();
+
+  if (!text) return "";
+
+  // Take first line
+  const firstLine = text.split("\n")[0].trim();
+
+  // Take first sentence (if there's a period, question mark, or exclamation)
+  const sentenceMatch = firstLine.match(/^(.+?[.?!。？！])\s/);
+  const phrase = sentenceMatch ? sentenceMatch[1] : firstLine;
+
+  // Truncate individual phrase
+  if (phrase.length > 60) {
+    return phrase.slice(0, 58) + "…";
+  }
+
+  return phrase;
+}


### PR DESCRIPTION
## 변경 요약
토픽 닫기(Cmd+D) 시 대화 요약을 IndexedDB에 저장

- topic-summary.ts: 클라이언트 요약 생성 (LLM 없이)
- chat-panel.tsx: 닫기 시 요약 생성+저장
- session-switcher.tsx: 닫힌 토픽에 요약 미리보기
- 14개 테스트

Related: #150