### PR TITLE
feat: add swipe mode toggle — agent vs topic (#173)

### DIFF
--- a/apps/web/src/__tests__/issue-173-swipe-mode-toggle.test.ts
+++ b/apps/web/src/__tests__/issue-173-swipe-mode-toggle.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getNextTopicIndex,
+  getSwipeMode,
+  setSwipeMode,
+} from "@/lib/hooks/use-swipe-gesture";
+
+// Mock localStorage
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: vi.fn((key: string) => store[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+  removeItem: vi.fn((key: string) => { delete store[key]; }),
+  clear: vi.fn(() => { for (const k of Object.keys(store)) delete store[k]; }),
+  get length() { return Object.keys(store).length; },
+  key: vi.fn((i: number) => Object.keys(store)[i] ?? null),
+};
+Object.defineProperty(globalThis, "localStorage", { value: localStorageMock, writable: true });
+
+describe("Issue #173: 스와이프 모드 토글 — 에이전트 vs 토픽", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  describe("getNextTopicIndex — 토픽 순환 로직", () => {
+    it("왼쪽 스와이프 → 다음 토픽", () => {
+      expect(getNextTopicIndex(0, 3, "left")).toBe(1);
+    });
+
+    it("오른쪽 스와이프 → 이전 토픽", () => {
+      expect(getNextTopicIndex(1, 3, "right")).toBe(0);
+    });
+
+    it("마지막에서 left → 첫 번째 (circular)", () => {
+      expect(getNextTopicIndex(2, 3, "left")).toBe(0);
+    });
+
+    it("첫 번째에서 right → 마지막 (circular)", () => {
+      expect(getNextTopicIndex(0, 3, "right")).toBe(2);
+    });
+
+    it("토픽 1개면 항상 0", () => {
+      expect(getNextTopicIndex(0, 1, "left")).toBe(0);
+      expect(getNextTopicIndex(0, 1, "right")).toBe(0);
+    });
+  });
+
+  describe("getSwipeMode / setSwipeMode — localStorage 저장/로드", () => {
+    it("기본값은 'agent'", () => {
+      expect(getSwipeMode()).toBe("agent");
+    });
+
+    it("'topic' 저장 후 로드", () => {
+      setSwipeMode("topic");
+      expect(getSwipeMode()).toBe("topic");
+      expect(localStorageMock.setItem).toHaveBeenCalledWith("awf:swipe-mode", "topic");
+    });
+
+    it("'agent' 저장 후 로드", () => {
+      setSwipeMode("agent");
+      expect(getSwipeMode()).toBe("agent");
+    });
+
+    it("저장값 변경 시 새 값 반영", () => {
+      setSwipeMode("topic");
+      expect(getSwipeMode()).toBe("topic");
+      setSwipeMode("agent");
+      expect(getSwipeMode()).toBe("agent");
+    });
+  });
+});

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -21,7 +21,7 @@ import { matchesShortcutId } from "@/lib/shortcuts";
 import { windowStoragePrefix } from "@/lib/utils";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
 import { useKeyboardHeight } from "@/lib/hooks/use-keyboard-height";
-import { useSwipeGesture, getNextAgentIndex } from "@/lib/hooks/use-swipe-gesture";
+import { useSwipeGesture, getNextAgentIndex, getNextTopicIndex, useSwipeMode } from "@/lib/hooks/use-swipe-gesture";
 import { NewSessionPicker, AgentManager } from "@/components/settings/agent-manager";
 import { SessionManagerPanel } from "./session-manager-panel";
 import { TopicHistory } from "./topic-history";
@@ -99,30 +99,59 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
   const [topicNameDialogOpen, setTopicNameDialogOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
 
-  // Swipe gesture for mobile agent switching
+  // Swipe mode: agent vs topic
+  const [swipeMode, setSwipeModeValue] = useSwipeMode(agents.length);
+
+  // Swipe gesture for mobile agent/topic switching
   const handleSwipeLeft = useCallback(() => {
-    if (agents.length <= 1) return;
-    const currentIdx = agents.findIndex((a) => a.id === agentId);
-    const nextIdx = getNextAgentIndex(
-      currentIdx === -1 ? 0 : currentIdx,
-      agents.length,
-      "left",
-    );
-    const nextAgent = agents[nextIdx];
-    if (nextAgent) handleAgentChange(nextAgent.id);
-  }, [agents, agentId]);
+    if (swipeMode === "topic") {
+      // 토픽 간 전환
+      if (agentSessions.length <= 1) return;
+      const currentIdx = agentSessions.findIndex((s) => s.key === effectiveSessionKey);
+      const nextIdx = getNextTopicIndex(
+        currentIdx === -1 ? 0 : currentIdx,
+        agentSessions.length,
+        "left",
+      );
+      if (agentSessions[nextIdx]) setSessionKey(agentSessions[nextIdx].key);
+    } else {
+      // 에이전트 간 전환
+      if (agents.length <= 1) return;
+      const currentIdx = agents.findIndex((a) => a.id === agentId);
+      const nextIdx = getNextAgentIndex(
+        currentIdx === -1 ? 0 : currentIdx,
+        agents.length,
+        "left",
+      );
+      const nextAgent = agents[nextIdx];
+      if (nextAgent) handleAgentChange(nextAgent.id);
+    }
+  }, [swipeMode, agents, agentId, agentSessions, effectiveSessionKey, setSessionKey]);
 
   const handleSwipeRight = useCallback(() => {
-    if (agents.length <= 1) return;
-    const currentIdx = agents.findIndex((a) => a.id === agentId);
-    const nextIdx = getNextAgentIndex(
-      currentIdx === -1 ? 0 : currentIdx,
-      agents.length,
-      "right",
-    );
-    const nextAgent = agents[nextIdx];
-    if (nextAgent) handleAgentChange(nextAgent.id);
-  }, [agents, agentId]);
+    if (swipeMode === "topic") {
+      // 토픽 간 전환
+      if (agentSessions.length <= 1) return;
+      const currentIdx = agentSessions.findIndex((s) => s.key === effectiveSessionKey);
+      const nextIdx = getNextTopicIndex(
+        currentIdx === -1 ? 0 : currentIdx,
+        agentSessions.length,
+        "right",
+      );
+      if (agentSessions[nextIdx]) setSessionKey(agentSessions[nextIdx].key);
+    } else {
+      // 에이전트 간 전환
+      if (agents.length <= 1) return;
+      const currentIdx = agents.findIndex((a) => a.id === agentId);
+      const nextIdx = getNextAgentIndex(
+        currentIdx === -1 ? 0 : currentIdx,
+        agents.length,
+        "right",
+      );
+      const nextAgent = agents[nextIdx];
+      if (nextAgent) handleAgentChange(nextAgent.id);
+    }
+  }, [swipeMode, agents, agentId, agentSessions, effectiveSessionKey, setSessionKey]);
 
   useSwipeGesture(panelRef, {
     onSwipeLeft: handleSwipeLeft,
@@ -871,6 +900,9 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
         onSelectSession={(key) => { setSessionKey(key); setSessionManagerOpen(false); }}
         onDeleteSession={async (key) => { await handleDelete(key); }}
         onResetSession={async (key) => { await handleReset(key); }}
+        swipeMode={swipeMode}
+        onSwipeModeChange={setSwipeModeValue}
+        isMobile={isMobile}
       />
 
       {/* Topic History Panel */}

--- a/apps/web/src/components/chat/session-manager-panel.tsx
+++ b/apps/web/src/components/chat/session-manager-panel.tsx
@@ -2,13 +2,14 @@
 import { useState, useMemo, useCallback } from "react";
 import {
   Bot, Pin, MessageCircle, Settings, Zap, Clock,
-  Trash2, RotateCcw, X, ChevronDown, ChevronRight,
+  Trash2, RotateCcw, X, ChevronDown, ChevronRight, Hand,
 } from "lucide-react";
 import { parseSessionKey, type GatewaySession } from "@/lib/gateway/session-utils";
 import { getHiddenSessions, unhideSession } from "@/lib/gateway/hidden-sessions";
 import type { Agent } from "@/lib/gateway/protocol";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
 import { cn } from "@/lib/utils";
+import type { SwipeMode } from "@/lib/hooks/use-swipe-gesture";
 
 interface SessionManagerPanelProps {
   open: boolean;
@@ -19,6 +20,9 @@ interface SessionManagerPanelProps {
   onSelectSession: (key: string) => void;
   onDeleteSession: (key: string) => Promise<void>;
   onResetSession: (key: string) => Promise<void>;
+  swipeMode?: SwipeMode;
+  onSwipeModeChange?: (mode: SwipeMode) => void;
+  isMobile?: boolean;
 }
 
 const TYPE_ICONS: Record<string, React.ReactNode> = {
@@ -70,6 +74,9 @@ export function SessionManagerPanel({
   onSelectSession,
   onDeleteSession,
   onResetSession,
+  swipeMode,
+  onSwipeModeChange,
+  isMobile,
 }: SessionManagerPanelProps) {
   const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set());
   const [confirmAction, setConfirmAction] = useState<{ key: string; action: "delete" | "reset" } | null>(null);
@@ -173,6 +180,31 @@ export function SessionManagerPanel({
           <span>{groups.length}개 에이전트</span>
           <span>{sessions.length}개 세션</span>
         </div>
+
+        {/* Swipe Mode Toggle (mobile) */}
+        {isMobile && onSwipeModeChange && (
+          <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-2.5">
+            <div className="flex items-center gap-1.5 text-[11px] font-medium text-zinc-400">
+              <Hand size={12} /> 스와이프 전환
+            </div>
+            <div className="flex gap-1">
+              {(["topic", "agent"] as const).map((mode) => (
+                <button
+                  key={mode}
+                  onClick={() => onSwipeModeChange(mode)}
+                  className={cn(
+                    "rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors",
+                    swipeMode === mode
+                      ? "bg-amber-600/80 text-white"
+                      : "bg-zinc-800 text-zinc-500 hover:bg-zinc-700 hover:text-zinc-300"
+                  )}
+                >
+                  {mode === "topic" ? "토픽" : "에이전트"}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Agent groups */}
         <div className="flex-1 overflow-y-auto">

--- a/apps/web/src/components/settings/session-settings.tsx
+++ b/apps/web/src/components/settings/session-settings.tsx
@@ -8,8 +8,10 @@ import {
   Monitor,
   Zap,
   ChevronDown,
+  Hand,
 } from "lucide-react";
 import { useSessionSettings } from "@/lib/gateway/use-session-settings";
+import type { SwipeMode } from "@/lib/hooks/use-swipe-gesture";
 
 const THINKING_LEVELS = ["off", "low", "medium", "high"] as const;
 type ThinkingLevel = (typeof THINKING_LEVELS)[number];
@@ -25,9 +27,12 @@ interface SessionSettingsProps {
   sessionKey?: string;
   onDelete?: () => void;
   onReset?: () => void;
+  swipeMode?: SwipeMode;
+  onSwipeModeChange?: (mode: SwipeMode) => void;
+  isMobile?: boolean;
 }
 
-export function SessionSettings({ sessionKey, onDelete, onReset }: SessionSettingsProps) {
+export function SessionSettings({ sessionKey, onDelete, onReset, swipeMode, onSwipeModeChange, isMobile }: SessionSettingsProps) {
   const { session, models, loading, patchSession, setThinking, setVerbose, resetSession, deleteSession, refresh } =
     useSessionSettings(sessionKey);
 
@@ -171,6 +176,30 @@ export function SessionSettings({ sessionKey, onDelete, onReset }: SessionSettin
               }`} />
             </button>
           </div>
+
+          {/* Swipe Mode (mobile only) */}
+          {isMobile && onSwipeModeChange && (
+            <div className="border-b border-zinc-800 px-3 py-2">
+              <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium text-zinc-500">
+                <Hand size={10} /> Swipe Mode
+              </div>
+              <div className="flex gap-1">
+                {(["topic", "agent"] as const).map((mode) => (
+                  <button
+                    key={mode}
+                    onClick={() => onSwipeModeChange(mode)}
+                    className={`flex-1 rounded-md py-1 text-[11px] font-medium transition-colors ${
+                      swipeMode === mode
+                        ? "bg-amber-600/80 text-white"
+                        : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-300"
+                    }`}
+                  >
+                    {mode === "topic" ? "토픽" : "에이전트"}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* Actions */}
           <div className="flex gap-2 px-3 py-2">

--- a/apps/web/src/lib/hooks/use-swipe-gesture.ts
+++ b/apps/web/src/lib/hooks/use-swipe-gesture.ts
@@ -1,6 +1,7 @@
-import { useEffect, useCallback, useRef } from "react";
+import { useEffect, useCallback, useRef, useState } from "react";
 
 export type SwipeDirection = "left" | "right";
+export type SwipeMode = "agent" | "topic";
 
 /**
  * 스와이프 방향 감지 (순수 함수)
@@ -39,6 +40,62 @@ export function getNextAgentIndex(
   if (total <= 1) return 0;
   const delta = direction === "right" ? 1 : -1;
   return (current + delta + total) % total;
+}
+
+/**
+ * 토픽(세션) 순환 인덱스 계산 (순수 함수)
+ */
+export function getNextTopicIndex(
+  current: number,
+  total: number,
+  direction: SwipeDirection,
+): number {
+  if (total <= 1) return 0;
+  const delta = direction === "left" ? 1 : -1;
+  return (current + delta + total) % total;
+}
+
+const SWIPE_MODE_KEY = "awf:swipe-mode";
+
+/**
+ * 스와이프 모드 저장/로드 (localStorage)
+ */
+export function getSwipeMode(): SwipeMode {
+  if (typeof window === "undefined") return "agent";
+  return (localStorage.getItem(SWIPE_MODE_KEY) as SwipeMode) || "agent";
+}
+
+export function setSwipeMode(mode: SwipeMode): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(SWIPE_MODE_KEY, mode);
+}
+
+/**
+ * 스와이프 모드 React 훅
+ * - localStorage에 저장/로드
+ * - 단일 에이전트 환경에서는 자동으로 토픽 모드 기본값
+ */
+export function useSwipeMode(agentCount: number): [SwipeMode, (mode: SwipeMode) => void] {
+  const [mode, setModeState] = useState<SwipeMode>(() => {
+    const stored = getSwipeMode();
+    // 단일 에이전트 환경에서는 토픽 모드 기본값
+    if (agentCount <= 1 && stored === "agent") return "topic";
+    return stored;
+  });
+
+  // agentCount 변경 시 자동 전환
+  useEffect(() => {
+    if (agentCount <= 1 && mode === "agent") {
+      setModeState("topic");
+    }
+  }, [agentCount, mode]);
+
+  const updateMode = useCallback((newMode: SwipeMode) => {
+    setSwipeMode(newMode);
+    setModeState(newMode);
+  }, []);
+
+  return [mode, updateMode];
 }
 
 /**


### PR DESCRIPTION
## 변경 요약
모바일 스와이프 전환 대상을 에이전트/토픽 간 선택 가능

### 추가 사항
- `use-swipe-gesture.ts`: `SwipeMode` 타입, `getNextTopicIndex`, `useSwipeMode` 훅, localStorage 저장/로드
- `chat-panel.tsx`: 스와이프 핸들러에서 모드에 따라 에이전트/토픽 전환 분기
- `session-manager-panel.tsx`: 세션 관리 패널에 스와이프 모드 토글 UI (모바일에서만 표시)
- `session-settings.tsx`: 스와이프 모드 props 지원
- localStorage 키: `awf:swipe-mode` (값: `agent` | `topic`)
- 단일 에이전트 환경에서는 자동으로 토픽 모드 기본값

### 테스트
- `issue-173-swipe-mode-toggle.test.ts`: 토픽 순환 로직 + localStorage 저장/로드 9개 테스트
- 기존 68개 테스트 파일 전체 통과 (1112 tests)

Closes #173