### PR TITLE
feat: Cmd+N duplicates current session in new window (#170)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, protocol, net, Menu, screen, dialog, nativeImage } from "electron";
+import { app, BrowserWindow, shell, protocol, net, Menu, screen, dialog, nativeImage, ipcMain } from "electron";
 import { join } from "path";
 import { readFileSync, writeFileSync } from "fs";
 
@@ -22,6 +22,9 @@ if (process.platform === "win32") {
 let mainWindow: BrowserWindow | null = null;
 let nextWindowId = 0;
 let isQuitting = false;
+
+// Track active session key per window (windowId → sessionKey)
+const windowSessionKeys = new Map<number, string>();
 
 // --- Window state persistence ---
 
@@ -79,6 +82,7 @@ function boundsVisible(bounds: Electron.Rectangle): boolean {
 interface CreateWindowOpts {
   windowId?: number;
   bounds?: Electron.Rectangle;
+  sessionKey?: string;
 }
 
 function createWindow(opts?: CreateWindowOpts): BrowserWindow {
@@ -137,10 +141,19 @@ function createWindow(opts?: CreateWindowOpts): BrowserWindow {
   const rendererUrl = process.env.ELECTRON_RENDERER_URL;
   console.log("[main] ELECTRON_RENDERER_URL:", rendererUrl);
 
+  // Append session query param if duplicating a session (#170)
+  const sessionParam = opts?.sessionKey ? `session=${encodeURIComponent(opts.sessionKey)}` : "";
+
   if (rendererUrl) {
-    win.loadURL(rendererUrl);
+    const separator = rendererUrl.includes("?") ? "&" : "?";
+    win.loadURL(sessionParam ? `${rendererUrl}${separator}${sessionParam}` : rendererUrl);
   } else {
-    win.loadFile(join(__dirname, "../renderer/index.html"));
+    const htmlPath = join(__dirname, "../renderer/index.html");
+    if (sessionParam) {
+      win.loadFile(htmlPath, { query: { session: opts!.sessionKey! } });
+    } else {
+      win.loadFile(htmlPath);
+    }
   }
 
   // Persist window states on move/resize (debounced) so dev crashes don't lose state
@@ -283,6 +296,17 @@ app.whenReady().then(() => {
   registerProtocol();
   registerIpcHandlers();
 
+  // IPC: renderer reports its active session key (#170)
+  ipcMain.on("session:update", (event, sessionKey: string) => {
+    // Find the windowId for the sender
+    for (const [wid, win] of windowMap) {
+      if (!win.isDestroyed() && win.webContents === event.sender) {
+        windowSessionKeys.set(wid, sessionKey);
+        break;
+      }
+    }
+  });
+
   // Restore previous windows, or create a fresh one
   const savedStates = loadWindowStates();
   if (savedStates.length > 0) {
@@ -324,7 +348,21 @@ app.whenReady().then(() => {
         {
           label: "New Window",
           accelerator: "CmdOrCtrl+N",
-          click: () => createWindow(),
+          click: () => {
+            // Duplicate current session in new window (#170)
+            const focused = BrowserWindow.getFocusedWindow();
+            let sessionKey: string | undefined;
+            if (focused) {
+              // Find the windowId for the focused window
+              for (const [wid, win] of windowMap) {
+                if (win === focused) {
+                  sessionKey = windowSessionKeys.get(wid);
+                  break;
+                }
+              }
+            }
+            createWindow(sessionKey ? { sessionKey } : undefined);
+          },
         },
         { role: "close" },
       ],

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -7,6 +7,8 @@ const windowId = windowIdArg ? parseInt(windowIdArg.split("=")[1], 10) : 0;
 const electronAPI = {
   windowId,
   getVersion: () => ipcRenderer.invoke("app:version") as Promise<string>,
+  /** Notify main process of current active session key (#170) */
+  updateSessionKey: (sessionKey: string) => ipcRenderer.send("session:update", sessionKey),
   platform: {
     mediaInfo: (filePath: string) => ipcRenderer.invoke("media:info", filePath),
     mediaServe: (filePath: string) => ipcRenderer.invoke("media:serve", filePath),

--- a/apps/web/src/__tests__/issue-170-cmd-n-session-duplicate.test.ts
+++ b/apps/web/src/__tests__/issue-170-cmd-n-session-duplicate.test.ts
@@ -1,0 +1,124 @@
+/**
+ * #170 — Cmd+N 새 창에서 현재 세션 복제
+ *
+ * 검증 대상:
+ * 1. resolveInitialSessionState — ?session= query param이 최우선
+ * 2. urlSearch 없을 때 기존 동작 유지
+ * 3. malformed urlSearch 무시
+ */
+import { describe, it, expect } from "vitest";
+import { resolveInitialSessionState } from "@/lib/session-continuity";
+
+describe("#170 — Cmd+N session duplication via URL query param", () => {
+  const defaultAgentId = "ops";
+  const emptyGetItem = () => null;
+
+  it("should use ?session= query param as highest priority", () => {
+    const result = resolveInitialSessionState({
+      windowPrefix: "",
+      defaultAgentId,
+      getItem: emptyGetItem,
+      urlSearch: "?session=agent%3Aops%3Amain",
+    });
+
+    expect(result.sessionKey).toBe("agent:ops:main");
+    expect(result.agentId).toBe(defaultAgentId);
+  });
+
+  it("should prefer ?session= over localStorage values", () => {
+    const storage: Record<string, string> = {
+      "awf:sessionKey": "agent:ops:old-session",
+      "awf:lastSessionKey:ops": "agent:ops:remembered",
+    };
+
+    const result = resolveInitialSessionState({
+      windowPrefix: "",
+      defaultAgentId,
+      getItem: (k) => storage[k] ?? null,
+      urlSearch: "?session=agent%3Aops%3Atopic%3A123",
+    });
+
+    expect(result.sessionKey).toBe("agent:ops:topic:123");
+  });
+
+  it("should fall back to localStorage when no ?session= param", () => {
+    const storage: Record<string, string> = {
+      "awf:sessionKey": "agent:ops:main",
+    };
+
+    const result = resolveInitialSessionState({
+      windowPrefix: "",
+      defaultAgentId,
+      getItem: (k) => storage[k] ?? null,
+      urlSearch: "",
+    });
+
+    expect(result.sessionKey).toBe("agent:ops:main");
+  });
+
+  it("should fall back to localStorage when urlSearch is undefined", () => {
+    const storage: Record<string, string> = {
+      "awf:sessionKey": "agent:ops:main",
+    };
+
+    const result = resolveInitialSessionState({
+      windowPrefix: "",
+      defaultAgentId,
+      getItem: (k) => storage[k] ?? null,
+    });
+
+    expect(result.sessionKey).toBe("agent:ops:main");
+  });
+
+  it("should handle ?session= with special characters", () => {
+    const result = resolveInitialSessionState({
+      windowPrefix: "",
+      defaultAgentId,
+      getItem: emptyGetItem,
+      urlSearch: "?session=agent%3Aops%3Asubagent%3Aabc-123",
+    });
+
+    expect(result.sessionKey).toBe("agent:ops:subagent:abc-123");
+  });
+
+  it("should ignore malformed urlSearch gracefully", () => {
+    // resolveInitialSessionState should not throw
+    const result = resolveInitialSessionState({
+      windowPrefix: "",
+      defaultAgentId,
+      getItem: emptyGetItem,
+      urlSearch: "not-a-valid-search",
+    });
+
+    // No session= param found, falls through to undefined
+    expect(result.sessionKey).toBeUndefined();
+  });
+
+  it("should work with window prefix for multi-window isolation", () => {
+    const storage: Record<string, string> = {
+      "awf:w1:sessionKey": "agent:ops:window-1-session",
+    };
+
+    const result = resolveInitialSessionState({
+      windowPrefix: "w1:",
+      defaultAgentId,
+      getItem: (k) => storage[k] ?? null,
+      urlSearch: "?session=agent%3Aops%3Aduplicated",
+    });
+
+    // URL param still wins over window-scoped storage
+    expect(result.sessionKey).toBe("agent:ops:duplicated");
+  });
+
+  it("should handle empty ?session= value", () => {
+    const result = resolveInitialSessionState({
+      windowPrefix: "",
+      defaultAgentId,
+      getItem: emptyGetItem,
+      urlSearch: "?session=",
+    });
+
+    // Empty string is falsy, should fall through
+    expect(result.sessionKey).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -51,6 +51,7 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
       windowPrefix: windowStoragePrefix(),
       defaultAgentId: import.meta.env.VITE_DEFAULT_AGENT || "default",
       getItem: (k) => localStorage.getItem(k),
+      urlSearch: window.location.search,
     });
     setSessionKeyRaw(initial.sessionKey);
     setAgentId(initial.agentId);
@@ -83,6 +84,15 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
 
   const effectiveSessionKey =
     sessionKey || (agentId ? `agent:${agentId}:main` : mainSessionKey) || undefined;
+
+  // Report active session to Electron main process for Cmd+N duplication (#170)
+  useEffect(() => {
+    if (typeof window === "undefined" || !effectiveSessionKey) return;
+    const api = (window as Record<string, unknown>).electronAPI as
+      | { updateSessionKey?: (key: string) => void }
+      | undefined;
+    api?.updateSessionKey?.(effectiveSessionKey);
+  }, [effectiveSessionKey]);
 
   const { messages, streaming, loading, agentStatus, sendMessage, sendCommand, addUserMessage, addLocalMessage, clearMessages, cancelQueued, abort, sendContextBridge, replyingTo, setReplyTo, clearReplyTo } = useChat(effectiveSessionKey);
   const { agents } = useAgents();

--- a/apps/web/src/lib/session-continuity.ts
+++ b/apps/web/src/lib/session-continuity.ts
@@ -27,8 +27,22 @@ export function resolveInitialSessionState(params: {
   windowPrefix: string;
   defaultAgentId: string;
   getItem: (key: string) => string | null;
+  /** URL search string (e.g. window.location.search) for ?session= override (#170) */
+  urlSearch?: string;
 }): { agentId: string; sessionKey?: string } {
-  const { windowPrefix, defaultAgentId, getItem } = params;
+  const { windowPrefix, defaultAgentId, getItem, urlSearch } = params;
+
+  // #170: URL query param takes highest priority (Cmd+N session duplication)
+  let urlSessionKey: string | undefined;
+  if (urlSearch) {
+    try {
+      const qp = new URLSearchParams(urlSearch);
+      const s = qp.get("session");
+      if (s) urlSessionKey = s;
+    } catch {
+      // ignore malformed search string
+    }
+  }
 
   // Post SplitView removal: scoped prefix matches chat-panel's storagePrefix
   const scopedPrefix = `awf:${windowPrefix}`;
@@ -40,6 +54,7 @@ export function resolveInitialSessionState(params: {
   const keys = buildSessionContinuityKeys({ windowPrefix, agentId });
 
   const sessionKey =
+    urlSessionKey ||
     getItem(keys.scopedSessionKey) ||
     getItem(keys.agentRememberedSessionKey) ||
     getItem(keys.legacyPanelSessionKey) ||


### PR DESCRIPTION
## 변경 요약
Cmd+N 새 창 열 때 현재 세션을 복제하여 같은 대화 표시

### 구현 내역
- **Electron main**: 활성 세션키를 윈도우별로 추적 (`windowSessionKeys` Map)
- **IPC**: renderer → main `session:update` 채널로 세션키 동기화
- **Preload**: `updateSessionKey()` API 노출
- **Cmd+N 핸들러**: 포커스된 윈도우의 세션키를 읽어 새 윈도우에 `?session=` query param으로 전달
- **createWindow**: URL에 session query param 추가 (dev/prod 모두 지원)
- **resolveInitialSessionState**: `?session=` URL param을 최우선으로 처리
- **Chat panel**: `effectiveSessionKey` 변경 시 Electron main에 보고

### 동작 방식
1. 사용자가 세션 A에서 대화 중
2. Cmd+N → 포커스 윈도우의 세션키(A)를 가져옴
3. 새 BrowserWindow 생성, URL에 `?session=agent:ops:main` 추가
4. 새 윈도우의 웹앱이 URL param에서 세션키를 읽어 자동 연결
5. WebSocket이 같은 세션에 연결 → 양쪽 창에서 실시간 동기화

### 테스트
- 8개 단위 테스트 추가 (URL param 우선순위, fallback, 특수문자, edge cases)
- 전체 1111 tests 통과
- Web + Desktop 빌드 확인

Closes #170