### PR TITLE
fix: detect compaction/system messages and render with distinct styling (#187)

### DIFF
--- a/apps/web/src/__tests__/issue-187-compaction-display.test.ts
+++ b/apps/web/src/__tests__/issue-187-compaction-display.test.ts
@@ -1,0 +1,106 @@
+/**
+ * issue-187-compaction-display.test.ts
+ *
+ * TDD tests for detecting compaction/system-injected messages
+ * that arrive with role="user" from OpenClaw gateway.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  detectSystemInjectedType,
+  type SystemInjectedType,
+} from "@/lib/gateway/hooks";
+
+// ---------------------------------------------------------------------------
+// detectSystemInjectedType(role, content)
+// Returns null for normal messages, or a SystemInjectedType for system-injected
+// ---------------------------------------------------------------------------
+describe("detectSystemInjectedType", () => {
+  // --- Should NOT detect as system-injected ---
+  describe("normal user messages", () => {
+    it("returns null for regular user text", () => {
+      expect(detectSystemInjectedType("user", "안녕하세요")).toBeNull();
+    });
+
+    it("returns null for assistant messages", () => {
+      expect(detectSystemInjectedType("assistant", "[System Message] test")).toBeNull();
+    });
+
+    it("returns null for user message containing 'summary' mid-text", () => {
+      expect(detectSystemInjectedType("user", "Here is a summary of today")).toBeNull();
+    });
+
+    it("returns null for user message mentioning 'compacted' mid-text", () => {
+      expect(detectSystemInjectedType("user", "I compacted the data yesterday")).toBeNull();
+    });
+
+    it("returns null for empty content", () => {
+      expect(detectSystemInjectedType("user", "")).toBeNull();
+    });
+
+    it("returns null for user message starting with 'The' but not compaction", () => {
+      expect(detectSystemInjectedType("user", "The weather is nice today")).toBeNull();
+    });
+  });
+
+  // --- Existing patterns (must keep working) ---
+  describe("existing system-injected patterns", () => {
+    it("detects [System Message] prefix", () => {
+      expect(detectSystemInjectedType("user", "[System Message] Session reset")).toBe("generic");
+    });
+
+    it("detects [sessionId: ...] prefix", () => {
+      expect(detectSystemInjectedType("user", "[sessionId:abc123] some context")).toBe("generic");
+    });
+
+    it("detects System: [ prefix", () => {
+      expect(detectSystemInjectedType("user", "System: [timestamp] event")).toBe("generic");
+    });
+  });
+
+  // --- Compaction summary patterns ---
+  describe("compaction summary detection", () => {
+    it("detects compaction header line", () => {
+      const content = "The conversation history before this point was compacted into the following summary:\n<summary>\nUser asked about weather.\n</summary>";
+      expect(detectSystemInjectedType("user", content)).toBe("compaction");
+    });
+
+    it("detects compaction with slight wording variation", () => {
+      const content = "The conversation history before this point was compacted into the following summary:\n\nSome summary text";
+      expect(detectSystemInjectedType("user", content)).toBe("compaction");
+    });
+
+    it("detects content starting with <summary> tag", () => {
+      const content = "<summary>\nThe user discussed project architecture.\n</summary>";
+      expect(detectSystemInjectedType("user", content)).toBe("compaction");
+    });
+  });
+
+  // --- Pre-compaction memory flush ---
+  describe("memory flush detection", () => {
+    it("detects pre-compaction memory flush", () => {
+      const content = "Pre-compaction memory flush.\nKey decisions: use Redis for caching.";
+      expect(detectSystemInjectedType("user", content)).toBe("memory-flush");
+    });
+
+    it("detects pre-compaction memory flush (exact match)", () => {
+      expect(detectSystemInjectedType("user", "Pre-compaction memory flush.")).toBe("memory-flush");
+    });
+  });
+
+  // --- Edge cases ---
+  describe("edge cases", () => {
+    it("handles multiline content correctly (compaction header on first line)", () => {
+      const content = "The conversation history before this point was compacted into the following summary:\n<summary>short</summary>\n\nMore stuff";
+      expect(detectSystemInjectedType("user", content)).toBe("compaction");
+    });
+
+    it("does not false-positive on assistant role even with compaction text", () => {
+      const content = "The conversation history before this point was compacted into the following summary:";
+      expect(detectSystemInjectedType("assistant", content)).toBeNull();
+    });
+
+    it("handles system role — returns null (already handled separately)", () => {
+      expect(detectSystemInjectedType("system", "anything")).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/components/chat/message-list.tsx
+++ b/apps/web/src/components/chat/message-list.tsx
@@ -4,11 +4,11 @@ import {
   User, Bot, Clock, X, Copy, Check, ArrowDown, Download,
   FileText, Music, Video, File, Image as ImageIcon,
   FileSpreadsheet, FileCode, FileArchive, FileAudio, FileVideo,
-  RefreshCw, History, Loader2, Reply,
+  RefreshCw, History, Loader2, Reply, ChevronDown,
 } from "lucide-react";
 import { MarkdownRenderer, MarkdownFilePreview } from "./markdown-renderer";
 import { ToolCallCard } from "./tool-call-card";
-import { HIDDEN_REPLY_RE, canBeReplyTarget, stripTrailingControlTokens, type DisplayMessage, type DisplayAttachment, type AgentStatus } from "@/lib/gateway/hooks";
+import { HIDDEN_REPLY_RE, canBeReplyTarget, stripTrailingControlTokens, type DisplayMessage, type DisplayAttachment, type AgentStatus, type SystemInjectedType } from "@/lib/gateway/hooks";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
 
 import { blobDownload, forceDownloadUrl } from "@/lib/utils/download";
@@ -538,6 +538,32 @@ export function MessageList({
   );
 }
 
+/** Collapsible system message for compaction summaries and memory flush (#187) */
+function CollapsibleSystemMessage({ content, systemType }: { content: string; systemType: SystemInjectedType }) {
+  const [expanded, setExpanded] = useState(false);
+  const label = systemType === "compaction" ? "Compaction Summary" : "Memory Flush";
+
+  return (
+    <div className="max-w-[90%] rounded-lg border border-zinc-700/50 bg-zinc-800/30 text-xs text-muted-foreground">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left transition hover:bg-zinc-700/30"
+      >
+        <ChevronDown
+          size={12}
+          className={`shrink-0 transition-transform ${expanded ? "" : "-rotate-90"}`}
+        />
+        <span className="font-medium text-zinc-400">{label}</span>
+      </button>
+      {expanded && (
+        <div className="border-t border-zinc-700/40 px-3 py-2 prose prose-sm prose-invert max-w-none">
+          <MarkdownRenderer content={content} />
+        </div>
+      )}
+    </div>
+  );
+}
+
 function SessionBoundary({
   reason,
   onLoadContext,
@@ -728,13 +754,17 @@ const MessageBubble = React.memo(React.forwardRef<HTMLDivElement, { message: Dis
   const isQueued = message.queued;
   const time = formatTime(message.timestamp);
 
-  // System messages: centered, muted style
+  // System messages: centered, muted style — collapsible for compaction/memory-flush (#187)
   if (isSystem) {
     return (
       <div ref={ref} className="flex justify-center py-1">
-        <div className="max-w-[90%] rounded-lg border border-border/50 bg-muted/30 px-4 py-2 text-center text-xs text-muted-foreground">
-          <MarkdownRenderer content={message.content} />
-        </div>
+        {message.systemType === "compaction" || message.systemType === "memory-flush" ? (
+          <CollapsibleSystemMessage content={message.content} systemType={message.systemType} />
+        ) : (
+          <div className="max-w-[90%] rounded-lg border border-border/50 bg-muted/30 px-4 py-2 text-center text-xs text-muted-foreground">
+            <MarkdownRenderer content={message.content} />
+          </div>
+        )}
       </div>
     );
   }

--- a/apps/web/src/lib/gateway/hooks.tsx
+++ b/apps/web/src/lib/gateway/hooks.tsx
@@ -374,6 +374,30 @@ export interface ReplyTo {
   role: string;
 }
 
+/** Type of system-injected message detected from user-role content */
+export type SystemInjectedType = "compaction" | "memory-flush" | "generic";
+
+/**
+ * Detect whether a message with the given role/content is a system-injected
+ * message masquerading as a user message.
+ * Returns null for normal messages, or the detected type.
+ */
+export function detectSystemInjectedType(role: string, content: string): SystemInjectedType | null {
+  if (role !== "user" || !content) return null;
+
+  // Compaction summary patterns
+  if (/^The conversation history.*compacted/.test(content)) return "compaction";
+  if (/^<summary>/.test(content)) return "compaction";
+
+  // Pre-compaction memory flush
+  if (/^Pre-compaction memory flush/.test(content)) return "memory-flush";
+
+  // Existing generic system-injected patterns
+  if (/^\[System Message\]|^\[sessionId:|^System:\s*\[/.test(content)) return "generic";
+
+  return null;
+}
+
 export interface DisplayMessage {
   id: string;
   role: "user" | "assistant" | "system" | "session-boundary";
@@ -388,6 +412,8 @@ export interface DisplayMessage {
   /** #156: Why the session was reset */
   resetReason?: string;
   replyTo?: ReplyTo;
+  /** #187: Type of system-injected message (for distinct rendering) */
+  systemType?: SystemInjectedType;
 }
 
 /**
@@ -905,23 +931,27 @@ export function useChat(sessionKey?: string) {
           const allAttachments = [...imgAttachments, ...mediaAttachments];
           if (m.role === 'assistant') textContent = stripTemplateVars(textContent);
 
-          // Check ORIGINAL content for system-injected markers (before stripping) (#55)
-          // Use ^ anchors to avoid false positives on user text containing these substrings mid-text
+          // Check ORIGINAL content for system-injected markers (before stripping) (#55, #187)
           const rawContentStr = typeof m.content === 'string' ? m.content : textContent;
-          const isSystemInjected = m.role === 'user' && /^\[System Message\]|^\[sessionId:|^System:\s*\[/.test(rawContentStr);
+          const systemType = detectSystemInjectedType(m.role, rawContentStr);
 
           return {
             id: `hist-${i}`,
-            role: (m.role === 'system' || isSystemInjected)
+            role: (m.role === 'system' || systemType)
               ? 'system' as const
               : m.role as "user" | "assistant",
             content: textContent,
             timestamp: m.timestamp || new Date().toISOString(),
             toolCalls: m.toolCalls || [],
             attachments: allAttachments.length > 0 ? allAttachments : undefined,
+            systemType: systemType ?? undefined,
           };
         })
-        .filter((m) => !isHiddenMessage(m.role, m.content));
+        .filter((m) => {
+          // Show compaction/memory-flush messages with distinct styling (#187)
+          if (m.systemType === 'compaction' || m.systemType === 'memory-flush') return true;
+          return !isHiddenMessage(m.role, m.content);
+        });
 
       // Dedup gateway messages in case the API returns duplicates (#121)
       const dedupedHistMsgs = deduplicateMessages(histMsgs);


### PR DESCRIPTION
Closes #187

## Changes
- Extract `detectSystemInjectedType()` function to detect compaction summaries, memory flush, and existing system-injected patterns from user-role messages
- Add `systemType` field to `DisplayMessage` for type-aware rendering
- Collapsible UI for compaction/memory-flush messages (centered, muted, expandable)
- Unit tests for all detection patterns (17 test cases)

## Detection patterns
| Pattern | Type |
|---------|------|
| `^The conversation history.*compacted` | compaction |
| `^<summary>` | compaction |
| `^Pre-compaction memory flush` | memory-flush |
| `^\[System Message\]` / `^\[sessionId:` / `^System: \[` | generic (existing) |

## Test plan
- [x] All 1137 tests pass (70 test files)
- [x] New test file with 17 cases covering all patterns + edge cases
- [ ] Visual verification: compaction messages appear as collapsible centered cards
- [ ] Verify normal user messages are not affected

Generated with [Claude Code](https://claude.com/claude-code)