### PR TITLE
fix: restore Cmd+T topic creation (v0.2.15 regression) (#194)

### DIFF
--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -886,6 +886,16 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
         sessionKey={effectiveSessionKey}
       />
 
+      {/* Topic Name Dialog */}
+      <TopicNameDialog
+        open={topicNameDialogOpen}
+        onConfirm={(name) => {
+          setTopicNameDialogOpen(false);
+          createSessionForAgent(agentId, name);
+        }}
+        onCancel={() => setTopicNameDialogOpen(false)}
+      />
+
       {/* New Session Picker */}
       <NewSessionPicker
         open={newSessionPickerOpen}


### PR DESCRIPTION
## Problem

Cmd+T to create a new topic stopped working in v0.2.15. The topic name input dialog never appeared.

## Root Cause

During the merge of PR #179 (swipe mode / topic switching), the `<TopicNameDialog>` JSX element was accidentally removed from `chat-panel.tsx`. The import, state (`topicNameDialogOpen`), and all `setTopicNameDialogOpen(true)` calls survived — but the actual component rendering was deleted, so the dialog was never shown.

## Fix

Re-added the `<TopicNameDialog>` rendering after the chat input component, restoring Cmd+T, toolbar button, and session manager topic creation.

Closes #194