### PR TITLE
fix: scroll to bottom on swipe chat transition

### DIFF
--- a/apps/mobile/src/components/chat/AgentChatPage.tsx
+++ b/apps/mobile/src/components/chat/AgentChatPage.tsx
@@ -73,6 +73,17 @@ export function AgentChatPage({ sessionKey, agentId, isActive, headerHeight = 0 
     }
   }, [messages.length, streaming]);
 
+  // Scroll to bottom when page becomes active (swipe transition)
+  useEffect(() => {
+    if (isActive && !loading && filteredMessages.length > 0) {
+      setTimeout(() => {
+        flatListRef.current?.scrollToEnd({ animated: false });
+        isAtBottomRef.current = true;
+        setUserScrolledUp(false);
+      }, 50);
+    }
+  }, [isActive, loading]);
+
   const scrollToBottom = useCallback(() => {
     flatListRef.current?.scrollToEnd({ animated: true });
     setUserScrolledUp(false);


### PR DESCRIPTION
## Summary

- **문제**: PagerView 스와이프로 에이전트 채팅 전환 시 FlatList 스크롤이 최상단에 위치해 최신 대화를 바로 볼 수 없음
- **원인**: `AgentChatPage`에서 `isActive`가 `false → true`로 전환될 때 `scrollToEnd`를 호출하는 로직 부재
- **수정**: `isActive` 전환 시 `scrollToEnd({ animated: false })`를 호출하는 useEffect 추가. 50ms 딜레이로 PagerView 전환 애니메이션 완료 후 실행

## Test plan

- [ ] 스와이프로 에이전트 채팅 전환 후 최하단 스크롤 위치 확인
- [ ] 빈 세션에서 스와이프 시 에러 없음 확인
- [ ] 히스토리 로딩 중 스와이프 후 로딩 완료 시 최하단 이동 확인
- [ ] 기존 자동 스크롤(새 메시지 수신 시) 동작 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)