### PR TITLE
fix: Gateway client stability — listener dedup, sequence gap detection, auth error classification

### DIFF
--- a/apps/web/src/__tests__/gateway-client-stability.test.ts
+++ b/apps/web/src/__tests__/gateway-client-stability.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Gateway Client Stability Tests
+ * Covers #226 (listener dedup), #227 (sequence gap detection), #228 (non-recoverable auth errors)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GatewayClient } from "@/lib/gateway/client";
+import type { EventFrame } from "@intelli-claw/shared/gateway/protocol";
+
+vi.mock("@intelli-claw/shared/gateway/device-identity", () => ({
+  signChallenge: vi.fn(async (nonce: string) => ({
+    id: "test-device-id",
+    publicKey: '{"kty":"EC","crv":"P-256"}',
+    signature: "dGVzdC1zaWduYXR1cmU=",
+    signedAt: 1700000000000,
+    nonce,
+  })),
+  initCryptoAdapter: vi.fn(),
+  getCryptoAdapter: vi.fn(),
+  clearDeviceIdentity: vi.fn(),
+}));
+
+// --- MockWebSocket ---
+class MockWebSocket {
+  static OPEN = 1;
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: ((e?: any) => void) | null = null;
+  onerror: ((e?: any) => void) | null = null;
+  sent: string[] = [];
+
+  constructor(public url: string) {
+    setTimeout(() => this.onopen?.(), 0);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.onclose?.();
+  }
+
+  simulateMessage(data: string) {
+    this.onmessage?.({ data });
+  }
+
+  simulateClose() {
+    this.onclose?.();
+  }
+}
+
+// --- Helper: complete handshake ---
+const HELLO_OK_PAYLOAD = {
+  type: "hello-ok",
+  protocol: 3,
+  server: { version: "1.0.0", connId: "c1" },
+  features: { methods: [], events: [] },
+  snapshot: {
+    presence: [],
+    health: {},
+    stateVersion: { presence: 0, health: 0 },
+    uptimeMs: 0,
+    sessionDefaults: { mainSessionKey: "agent:alpha:main" },
+  },
+  policy: { maxPayload: 1048576, maxBufferedBytes: 4194304, tickIntervalMs: 15000 },
+};
+
+async function completeHandshake(client: GatewayClient): Promise<MockWebSocket> {
+  client.connect();
+  await vi.advanceTimersByTimeAsync(1);
+
+  // @ts-expect-error private access
+  const ws = client.ws as MockWebSocket;
+
+  ws.simulateMessage(
+    JSON.stringify({ type: "event", event: "connect.challenge", payload: { nonce: "n1" } }),
+  );
+  await vi.advanceTimersByTimeAsync(1);
+
+  const connectReq = JSON.parse(ws.sent[0]);
+  ws.simulateMessage(
+    JSON.stringify({ type: "res", id: connectReq.id, ok: true, payload: HELLO_OK_PAYLOAD }),
+  );
+
+  return ws;
+}
+
+describe("Gateway Client Stability", () => {
+  let originalWebSocket: typeof globalThis.WebSocket;
+  let originalMathRandom: typeof Math.random;
+  let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+  let removeEventListenerSpy: ReturnType<typeof vi.spyOn>;
+  let docAddSpy: ReturnType<typeof vi.spyOn>;
+  let docRemoveSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    originalWebSocket = globalThis.WebSocket;
+    // @ts-expect-error mock
+    globalThis.WebSocket = MockWebSocket;
+    originalMathRandom = Math.random;
+    Math.random = () => 0;
+
+    // Spy on window/document event listeners
+    addEventListenerSpy = vi.spyOn(window, "addEventListener");
+    removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    docAddSpy = vi.spyOn(document, "addEventListener");
+    docRemoveSpy = vi.spyOn(document, "removeEventListener");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.WebSocket = originalWebSocket;
+    Math.random = originalMathRandom;
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+    docAddSpy.mockRestore();
+    docRemoveSpy.mockRestore();
+  });
+
+  // ─── #226: Event Listener Deduplication ─────────────────────
+
+  describe("#226: event listener deduplication", () => {
+    it("registers 'online' listener only once across connect calls", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      await completeHandshake(client);
+
+      // Count how many times "online" was added
+      const onlineCalls = addEventListenerSpy.mock.calls.filter(
+        ([event]) => event === "online",
+      );
+
+      // Should have exactly 1 "online" listener (not 2 from setupNetworkListeners + addBrowserListeners)
+      expect(onlineCalls.length).toBe(1);
+    });
+
+    it("registers 'visibilitychange' listener only once across connect calls", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      await completeHandshake(client);
+
+      const visibilityCalls = docAddSpy.mock.calls.filter(
+        ([event]) => event === "visibilitychange",
+      );
+
+      expect(visibilityCalls.length).toBe(1);
+    });
+
+    it("properly removes all listeners on disconnect", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      await completeHandshake(client);
+
+      client.disconnect();
+
+      // "online" should have been removed
+      const onlineRemoves = removeEventListenerSpy.mock.calls.filter(
+        ([event]) => event === "online",
+      );
+      expect(onlineRemoves.length).toBeGreaterThanOrEqual(1);
+
+      // "visibilitychange" should have been removed
+      const visibilityRemoves = docRemoveSpy.mock.calls.filter(
+        ([event]) => event === "visibilitychange",
+      );
+      expect(visibilityRemoves.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("uses the same handler reference for add/remove (proper cleanup)", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      await completeHandshake(client);
+
+      // Get the handler references that were added
+      const onlineAddCalls = addEventListenerSpy.mock.calls.filter(
+        ([event]) => event === "online",
+      );
+      const addedHandler = onlineAddCalls[0]?.[1];
+      expect(addedHandler).toBeDefined();
+
+      client.disconnect();
+
+      // The removed handler should be the same reference
+      const onlineRemoveCalls = removeEventListenerSpy.mock.calls.filter(
+        ([event]) => event === "online",
+      );
+      const removedHandler = onlineRemoveCalls[0]?.[1];
+      expect(removedHandler).toBe(addedHandler);
+    });
+
+    it("does not register new listeners on reconnect (reuses existing)", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      const ws = await completeHandshake(client);
+
+      const onlineCountBefore = addEventListenerSpy.mock.calls.filter(
+        ([event]) => event === "online",
+      ).length;
+
+      // Simulate unintentional close and reconnect
+      ws.simulateClose();
+      await vi.advanceTimersByTimeAsync(1002);
+
+      const onlineCountAfter = addEventListenerSpy.mock.calls.filter(
+        ([event]) => event === "online",
+      ).length;
+
+      // Should not have added more "online" listeners
+      expect(onlineCountAfter).toBe(onlineCountBefore);
+    });
+  });
+
+  // ─── #227: Sequence Gap Detection ──────────────────────────
+
+  describe("#227: sequence gap detection", () => {
+    it("detects gap when seq jumps (e.g. 1 -> 3)", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      const events: EventFrame[] = [];
+      client.onEvent((e) => events.push(e));
+      const ws = await completeHandshake(client);
+
+      // Send event with seq 1
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: { delta: "a" }, seq: 1 }),
+      );
+
+      // Send event with seq 3 (gap: seq 2 is missing)
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: { delta: "b" }, seq: 3 }),
+      );
+
+      // Should have emitted a client.sequence_gap synthetic event
+      const gapEvent = events.find((e) => e.event === "client.sequence_gap");
+      expect(gapEvent).toBeDefined();
+      expect(gapEvent!.payload).toEqual(
+        expect.objectContaining({ expected: 2, received: 3 }),
+      );
+    });
+
+    it("does not emit gap event for sequential events (1, 2, 3)", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      const events: EventFrame[] = [];
+      client.onEvent((e) => events.push(e));
+      const ws = await completeHandshake(client);
+
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: {}, seq: 1 }),
+      );
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: {}, seq: 2 }),
+      );
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: {}, seq: 3 }),
+      );
+
+      const gapEvents = events.filter((e) => e.event === "client.sequence_gap");
+      expect(gapEvents.length).toBe(0);
+    });
+
+    it("ignores events without seq field (no gap tracking)", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      const events: EventFrame[] = [];
+      client.onEvent((e) => events.push(e));
+      const ws = await completeHandshake(client);
+
+      // Event without seq
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: {} }),
+      );
+
+      // Event with seq 5 — no gap because lastSeq was never set
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: {}, seq: 5 }),
+      );
+
+      const gapEvents = events.filter((e) => e.event === "client.sequence_gap");
+      expect(gapEvents.length).toBe(0);
+    });
+
+    it("resets lastSeq on new connection", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      const events: EventFrame[] = [];
+      client.onEvent((e) => events.push(e));
+      const ws = await completeHandshake(client);
+
+      // Set lastSeq to 5
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: {}, seq: 5 }),
+      );
+
+      // Simulate close and reconnect
+      ws.simulateClose();
+      await vi.advanceTimersByTimeAsync(1002);
+
+      // Complete handshake on new connection
+      // @ts-expect-error private access
+      const ws2 = client.ws as MockWebSocket;
+      ws2.simulateMessage(
+        JSON.stringify({ type: "event", event: "connect.challenge", payload: { nonce: "n2" } }),
+      );
+      await vi.advanceTimersByTimeAsync(1);
+      const req = JSON.parse(ws2.sent[0]);
+      ws2.simulateMessage(
+        JSON.stringify({ type: "res", id: req.id, ok: true, payload: HELLO_OK_PAYLOAD }),
+      );
+
+      // Now send event with seq 1 — should NOT detect gap (lastSeq was reset)
+      ws2.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: {}, seq: 1 }),
+      );
+
+      const gapEvents = events.filter((e) => e.event === "client.sequence_gap");
+      expect(gapEvents.length).toBe(0);
+    });
+
+    it("detects multiple gaps in sequence", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      const events: EventFrame[] = [];
+      client.onEvent((e) => events.push(e));
+      const ws = await completeHandshake(client);
+
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: {}, seq: 1 }),
+      );
+      // Gap: 2 missing
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: {}, seq: 3 }),
+      );
+      // Gap: 4, 5 missing
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "agent", payload: {}, seq: 6 }),
+      );
+
+      const gapEvents = events.filter((e) => e.event === "client.sequence_gap");
+      expect(gapEvents.length).toBe(2);
+      expect((gapEvents[0].payload as any).expected).toBe(2);
+      expect((gapEvents[0].payload as any).received).toBe(3);
+      expect((gapEvents[1].payload as any).expected).toBe(4);
+      expect((gapEvents[1].payload as any).received).toBe(6);
+    });
+  });
+
+  // ─── #228: Non-Recoverable Auth Error Classification ───────
+
+  describe("#228: non-recoverable auth error classification", () => {
+    const NON_RECOVERABLE_CODES = [
+      "AUTH_TOKEN_MISSING",
+      "AUTH_TOKEN_MISMATCH",
+      "AUTH_PASSWORD_MISSING",
+      "AUTH_PASSWORD_MISMATCH",
+      "AUTH_RATE_LIMITED",
+      "PAIRING_REQUIRED",
+      "DEVICE_IDENTITY_REQUIRED",
+    ];
+
+    it("does not schedule reconnect for non-recoverable auth errors", async () => {
+      for (const code of NON_RECOVERABLE_CODES) {
+        const client = new GatewayClient("ws://localhost:18789", "tok");
+        client.connect();
+        await vi.advanceTimersByTimeAsync(1);
+
+        // @ts-expect-error private access
+        const ws = client.ws as MockWebSocket;
+
+        // Simulate connect.challenge
+        ws.simulateMessage(
+          JSON.stringify({ type: "event", event: "connect.challenge", payload: { nonce: "n1" } }),
+        );
+        await vi.advanceTimersByTimeAsync(1);
+
+        // Simulate auth error response to connect request
+        const connectReq = JSON.parse(ws.sent[0]);
+        ws.simulateMessage(
+          JSON.stringify({
+            type: "res",
+            id: connectReq.id,
+            ok: false,
+            error: {
+              code: "AUTH_FAILED",
+              message: `Authentication failed: ${code}`,
+              details: { code },
+            },
+          }),
+        );
+
+        // The auth error should cause ws close which calls handleClose
+        // Simulate ws closing after auth failure
+        ws.simulateClose();
+
+        expect(client.getState()).toBe("disconnected");
+
+        // Wait long enough for any reconnect to fire
+        await vi.advanceTimersByTimeAsync(65_000);
+
+        // Should still be disconnected — no reconnect attempt
+        expect(client.getState()).toBe("disconnected");
+
+        // Cleanup
+        client.disconnect();
+      }
+    });
+
+    it("schedules reconnect for recoverable errors (non-auth)", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      const ws = await completeHandshake(client);
+
+      // Simulate normal connection close (no auth error)
+      ws.simulateClose();
+      expect(client.getState()).toBe("disconnected");
+
+      // After reconnect delay, should attempt reconnect
+      await vi.advanceTimersByTimeAsync(1002);
+      expect(client.getState()).toBe("authenticating");
+
+      client.disconnect();
+    });
+
+    it("sets user-friendly error message for non-recoverable auth errors", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      client.connect();
+      await vi.advanceTimersByTimeAsync(1);
+
+      // @ts-expect-error private access
+      const ws = client.ws as MockWebSocket;
+
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "connect.challenge", payload: { nonce: "n1" } }),
+      );
+      await vi.advanceTimersByTimeAsync(1);
+
+      const connectReq = JSON.parse(ws.sent[0]);
+      ws.simulateMessage(
+        JSON.stringify({
+          type: "res",
+          id: connectReq.id,
+          ok: false,
+          error: {
+            code: "AUTH_FAILED",
+            message: "Token missing",
+            details: { code: "AUTH_TOKEN_MISSING" },
+          },
+        }),
+      );
+
+      ws.simulateClose();
+
+      // lastError should be set with details
+      expect(client.lastError).toBeDefined();
+      expect(client.lastError!.code).toBe("AUTH_FAILED");
+
+      client.disconnect();
+    });
+
+    it("emits client.auth_failed event for non-recoverable auth errors", async () => {
+      const client = new GatewayClient("ws://localhost:18789", "tok");
+      const events: EventFrame[] = [];
+      client.onEvent((e) => events.push(e));
+      client.connect();
+      await vi.advanceTimersByTimeAsync(1);
+
+      // @ts-expect-error private access
+      const ws = client.ws as MockWebSocket;
+
+      ws.simulateMessage(
+        JSON.stringify({ type: "event", event: "connect.challenge", payload: { nonce: "n1" } }),
+      );
+      await vi.advanceTimersByTimeAsync(1);
+
+      const connectReq = JSON.parse(ws.sent[0]);
+      ws.simulateMessage(
+        JSON.stringify({
+          type: "res",
+          id: connectReq.id,
+          ok: false,
+          error: {
+            code: "AUTH_FAILED",
+            message: "Token missing",
+            details: { code: "AUTH_TOKEN_MISSING" },
+          },
+        }),
+      );
+
+      ws.simulateClose();
+
+      const authFailedEvent = events.find((e) => e.event === "client.auth_failed");
+      expect(authFailedEvent).toBeDefined();
+      expect((authFailedEvent!.payload as any).detailCode).toBe("AUTH_TOKEN_MISSING");
+
+      client.disconnect();
+    });
+  });
+});

--- a/packages/shared/src/gateway/client.ts
+++ b/packages/shared/src/gateway/client.ts
@@ -33,6 +33,42 @@ const MAX_RECONNECT_ATTEMPTS = 20;
 const PING_INTERVAL = 25_000;
 const PONG_TIMEOUT = 10_000;
 
+/**
+ * Non-recoverable auth error detail codes (#228).
+ * When the gateway returns one of these, reconnecting won't help —
+ * the user must take action (fix token, pair device, etc.).
+ */
+const NON_RECOVERABLE_AUTH_DETAIL_CODES: ReadonlySet<string> = new Set([
+  "AUTH_TOKEN_MISSING",
+  "AUTH_TOKEN_MISMATCH",
+  "AUTH_PASSWORD_MISSING",
+  "AUTH_PASSWORD_MISMATCH",
+  "AUTH_RATE_LIMITED",
+  "PAIRING_REQUIRED",
+  "DEVICE_IDENTITY_REQUIRED",
+]);
+
+/**
+ * Extract the detail code from an error's details object.
+ * Gateway auth errors carry `{ details: { code: "AUTH_TOKEN_MISSING" } }`.
+ */
+function readErrorDetailCode(error: ErrorShape | null | undefined): string | null {
+  if (!error?.details || typeof error.details !== "object" || Array.isArray(error.details)) {
+    return null;
+  }
+  const code = (error.details as { code?: unknown }).code;
+  return typeof code === "string" && code.trim().length > 0 ? code : null;
+}
+
+/**
+ * Check whether an error represents a non-recoverable auth failure (#228).
+ * Returns true if the error's detail code is in the non-recoverable set.
+ */
+export function isNonRecoverableAuthError(error: ErrorShape | null | undefined): boolean {
+  const code = readErrorDetailCode(error);
+  return code !== null && NON_RECOVERABLE_AUTH_DETAIL_CODES.has(code);
+}
+
 export class GatewayClient {
   private ws: WebSocket | null = null;
   private url: string;
@@ -49,7 +85,8 @@ export class GatewayClient {
   private pingIds = new Set<string>();
   private intentionalClose = false;
   private wasConnected = false;
-  private networkCleanup: (() => void) | null = null;
+  /** Whether browser event listeners (online, visibilitychange) are registered (#226) */
+  private listenersRegistered = false;
   public mainSessionKey = "";
   public serverVersion = "";
   public serverCommit = "";
@@ -57,15 +94,28 @@ export class GatewayClient {
   public canvasHostUrl = "";
   private options: GatewayClientOptions;
 
+  /** Last connect error — used by handleClose to decide if reconnect is appropriate (#228) */
+  private lastConnectError: ErrorShape | null = null;
+
+  /** Last sequence number seen from gateway event frames (#227) */
+  private lastSeq: number | null = null;
+
+  /**
+   * Bound handler for the "online" window event (#226).
+   * Stored as an arrow-function instance field so the same reference
+   * is used for both addEventListener and removeEventListener.
+   */
   private handleOnline = (): void => {
-    // Network came back — if we're disconnected (not intentionally), reconnect immediately
     if (this.state === "disconnected" && !this.intentionalClose && this.wasConnected) {
       this.clearReconnect();
-      this.reconnectAttempt = 0; // reset — network change is a fresh start
+      this.reconnectAttempt = 0;
       this.connect();
     }
   };
 
+  /**
+   * Bound handler for the "visibilitychange" document event (#226).
+   */
   private handleVisibilityChange = (): void => {
     if (
       typeof document !== "undefined" &&
@@ -98,9 +148,10 @@ export class GatewayClient {
     if (this.ws && this.state !== "disconnected") return;
     this.intentionalClose = false;
     this.lastError = null;
-    this.setupNetworkListeners();
+    this.lastConnectError = null;
     this.setState("connecting");
-    this.addBrowserListeners();
+    // Register browser event listeners once (#226 — deduplicated)
+    this.setupBrowserListeners();
 
     try {
       this.ws = new WebSocket(this.url);
@@ -118,8 +169,7 @@ export class GatewayClient {
     this.clearReconnect();
     this.clearAuthTimer();
     this.stopPing();
-    this.teardownNetworkListeners();
-    this.removeBrowserListeners();
+    this.teardownBrowserListeners();
     if (this.ws) {
       this.ws.onclose = null;
       this.ws.close();
@@ -183,6 +233,10 @@ export class GatewayClient {
   }
 
   private handleOpen(): void {
+    // Reset sequence tracking on new connection (#227)
+    this.lastSeq = null;
+    this.lastConnectError = null;
+
     this.setState("authenticating");
     this.clearAuthTimer();
     this.authTimer = setTimeout(() => {
@@ -298,6 +352,21 @@ export class GatewayClient {
       return;
     }
 
+    // --- Sequence gap detection (#227) ---
+    const seq = typeof frame.seq === "number" ? frame.seq : null;
+    if (seq !== null) {
+      if (this.lastSeq !== null && seq > this.lastSeq + 1) {
+        // Emit synthetic gap event before the actual event
+        const gapFrame: EventFrame = {
+          type: "event",
+          event: "client.sequence_gap",
+          payload: { expected: this.lastSeq + 1, received: seq },
+        };
+        this.eventHandlers.forEach((h) => h(gapFrame));
+      }
+      this.lastSeq = seq;
+    }
+
     console.log("[AWF] Event:", frame.event, JSON.stringify(frame.payload).slice(0, 200));
     this.eventHandlers.forEach((h) => h(frame));
   }
@@ -314,13 +383,30 @@ export class GatewayClient {
       console.error("[AWF] Server error:", errObj?.code, errObj?.message, frame.error);
       if (errObj) {
         this.lastError = errObj;
+        // Track connect errors for non-recoverable auth classification (#228)
+        this.lastConnectError = errObj;
         this.stateHandlers.forEach((h) => h(this.state, this.lastError));
+
+        // Emit synthetic auth_failed event if non-recoverable (#228)
+        if (isNonRecoverableAuthError(errObj)) {
+          const authFailedFrame: EventFrame = {
+            type: "event",
+            event: "client.auth_failed",
+            payload: {
+              code: errObj.code,
+              message: errObj.message,
+              detailCode: readErrorDetailCode(errObj),
+            },
+          };
+          this.eventHandlers.forEach((h) => h(authFailedFrame));
+        }
       }
     }
 
     const payload = frame.payload as Record<string, unknown> | undefined;
     if (frame.ok && payload?.type === "hello-ok") {
       this.clearAuthTimer();
+      this.lastConnectError = null;
       const snapshot = payload.snapshot as Record<string, unknown> | undefined;
       const sessionDefaults = snapshot?.sessionDefaults as Record<string, unknown> | undefined;
       this.mainSessionKey = (sessionDefaults?.mainSessionKey as string) || "";
@@ -370,11 +456,17 @@ export class GatewayClient {
   private handleClose(): void {
     this.clearAuthTimer();
     this.stopPing();
+    const connectError = this.lastConnectError;
     this.ws = null;
     this.rejectAll("Connection closed");
     this.setState("disconnected");
 
     if (!this.intentionalClose) {
+      // Skip reconnect for non-recoverable auth errors (#228)
+      if (isNonRecoverableAuthError(connectError)) {
+        console.warn("[GW] Non-recoverable auth error, skipping reconnect:", readErrorDetailCode(connectError));
+        return;
+      }
       this.scheduleReconnect();
     }
   }
@@ -442,46 +534,35 @@ export class GatewayClient {
   }
 
   /**
-   * Listen for network/visibility changes to trigger reconnect (#119).
-   * On mobile, WiFi↔5G transitions and app backgrounding cause code 1006 closes.
+   * Register browser event listeners for network/visibility reconnect (#226).
+   * Uses stable instance-field handlers so the same reference is used for
+   * both addEventListener and removeEventListener — guaranteeing proper cleanup.
+   * Only registers once; subsequent connect() calls skip if already registered.
    */
-  private setupNetworkListeners(): void {
-    if (this.networkCleanup) return; // already set up
-    const handleOnline = () => {
-      if (this.state === "disconnected" && !this.intentionalClose) {
-        console.log("[GW] Network online — triggering reconnect");
-        this.reconnectAttempt = 0; // Reset backoff on network change
-        this.clearReconnect();
-        this.connect();
-      }
-    };
-    const handleVisibility = () => {
-      if (typeof document !== "undefined" && document.visibilityState === "visible") {
-        if (this.state === "disconnected" && !this.intentionalClose) {
-          console.log("[GW] Page visible — triggering reconnect");
-          this.reconnectAttempt = 0;
-          this.clearReconnect();
-          this.connect();
-        }
-      }
-    };
-    const hasWindowEvents = typeof window !== "undefined" && typeof window.addEventListener === "function";
-    const hasDocumentEvents = typeof document !== "undefined" && typeof document.addEventListener === "function";
-    if (hasWindowEvents) {
-      window.addEventListener("online", handleOnline);
+  private setupBrowserListeners(): void {
+    if (this.listenersRegistered) return;
+    if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
+      window.addEventListener("online", this.handleOnline);
     }
-    if (hasDocumentEvents) {
-      document.addEventListener("visibilitychange", handleVisibility);
+    if (typeof document !== "undefined" && typeof document.addEventListener === "function") {
+      document.addEventListener("visibilitychange", this.handleVisibilityChange);
     }
-    this.networkCleanup = () => {
-      if (hasWindowEvents) window.removeEventListener("online", handleOnline);
-      if (hasDocumentEvents) document.removeEventListener("visibilitychange", handleVisibility);
-    };
+    this.listenersRegistered = true;
   }
 
-  private teardownNetworkListeners(): void {
-    this.networkCleanup?.();
-    this.networkCleanup = null;
+  /**
+   * Remove browser event listeners (#226).
+   * Uses the same handler references that were registered in setupBrowserListeners.
+   */
+  private teardownBrowserListeners(): void {
+    if (!this.listenersRegistered) return;
+    if (typeof window !== "undefined" && typeof window.removeEventListener === "function") {
+      window.removeEventListener("online", this.handleOnline);
+    }
+    if (typeof document !== "undefined" && typeof document.removeEventListener === "function") {
+      document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+    }
+    this.listenersRegistered = false;
   }
 
   private clearReconnect(): void {
@@ -504,32 +585,5 @@ export class GatewayClient {
       p.reject(new Error(reason));
     });
     this.pending.clear();
-  }
-
-  // --- Browser event listeners for mobile reconnection ---
-
-  private browserListenersAdded = false;
-
-  private addBrowserListeners(): void {
-    if (this.browserListenersAdded) return;
-    if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
-      window.addEventListener("online", this.handleOnline);
-      window.addEventListener("offline", () => {}); // reserved for future offline handling
-    }
-    if (typeof document !== "undefined" && typeof document.addEventListener === "function") {
-      document.addEventListener("visibilitychange", this.handleVisibilityChange);
-    }
-    this.browserListenersAdded = true;
-  }
-
-  private removeBrowserListeners(): void {
-    if (!this.browserListenersAdded) return;
-    if (typeof window !== "undefined" && typeof window.removeEventListener === "function") {
-      window.removeEventListener("online", this.handleOnline);
-    }
-    if (typeof document !== "undefined" && typeof document.removeEventListener === "function") {
-      document.removeEventListener("visibilitychange", this.handleVisibilityChange);
-    }
-    this.browserListenersAdded = false;
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,5 @@
 // --- Gateway ---
-export { GatewayClient, type ConnectionState, type GatewayClientOptions, type InvokeHandler } from "./gateway/client";
+export { GatewayClient, isNonRecoverableAuthError, type ConnectionState, type GatewayClientOptions, type InvokeHandler } from "./gateway/client";
 export { NodeGatewayClient } from "./gateway/node-client";
 export {
   makeReq,


### PR DESCRIPTION
## Summary
- **#226**: `setupNetworkListeners()`와 `addBrowserListeners()` 중복 리스너 등록 → 단일 `setupBrowserListeners()`로 통합, `listenersRegistered` 플래그로 중복 방지
- **#227**: 이벤트 시퀀스 갭 감지 — `lastSeq` 추적, 갭 발견 시 `client.sequence_gap` synthetic 이벤트 emit
- **#228**: 비복구 인증 에러 분류 — `isNonRecoverableAuthError()` 함수, 해당 에러 시 재연결 skip + `client.auth_failed` 이벤트

## Test plan
- [x] `vitest run src/__tests__/gateway-client-stability.test.ts` — 14 tests passed
- [ ] E2E: 실제 Gateway 연결/재연결 동작 확인
- [ ] 잘못된 토큰으로 연결 시 재연결 미시도 확인

Closes #226, Closes #227, Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)