### PR TITLE
fix: preserve session on Cmd+R reload in new windows (#256)

### DIFF
--- a/apps/web/e2e/stream-segments.spec.ts
+++ b/apps/web/e2e/stream-segments.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * E2E tests for #231: Streaming segments — text↔tool interleave order preservation.
+ *
+ * Verifies that messages with interleaved text and tool calls render in order.
+ */
+import { test, expect } from "./helpers/fixtures";
+
+test.describe("Streaming Segments — Interleave Order (#231)", () => {
+  test("renders text↔tool segments in correct order from history", async ({ mockGateway }) => {
+    const page = await mockGateway({
+      historyMessages: [
+        { role: "user", content: "Analyze the code" },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me analyze the code for you." },
+            { type: "tool_use", id: "call-1", name: "read_file", input: { path: "src/app.ts" } },
+            { type: "text", text: "I found an issue in the file." },
+            { type: "tool_use", id: "call-2", name: "edit_file", input: { path: "src/app.ts" } },
+            { type: "text", text: "The fix has been applied successfully." },
+          ],
+        },
+      ],
+    });
+
+    // Wait for the message to render
+    await expect(page.getByText("Let me analyze the code for you.")).toBeVisible({ timeout: 5000 });
+
+    // All text segments should be visible
+    await expect(page.getByText("I found an issue in the file.")).toBeVisible();
+    await expect(page.getByText("The fix has been applied successfully.")).toBeVisible();
+
+    // Tool call cards should be visible
+    await expect(page.getByText("read_file")).toBeVisible();
+    await expect(page.getByText("edit_file")).toBeVisible();
+
+    // Verify order: get all segment elements within the assistant message
+    const assistantMsg = page.locator("[data-chat-panel] .group:not(.justify-end)").last();
+    const textContent = await assistantMsg.textContent();
+
+    // The text should appear in interleaved order (text before its corresponding tool)
+    const analyzeIdx = textContent!.indexOf("Let me analyze");
+    const readFileIdx = textContent!.indexOf("read_file");
+    const foundIdx = textContent!.indexOf("I found an issue");
+    const editFileIdx = textContent!.indexOf("edit_file");
+    const fixIdx = textContent!.indexOf("The fix has been");
+
+    expect(analyzeIdx).toBeLessThan(readFileIdx);
+    expect(readFileIdx).toBeLessThan(foundIdx);
+    expect(foundIdx).toBeLessThan(editFileIdx);
+    expect(editFileIdx).toBeLessThan(fixIdx);
+  });
+
+  test("falls back to legacy rendering when no segments", async ({ mockGateway }) => {
+    const page = await mockGateway({
+      historyMessages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there! How can I help?" },
+      ],
+    });
+
+    await expect(page.getByText("Hi there! How can I help?")).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/apps/web/e2e/tool-sidebar.spec.ts
+++ b/apps/web/e2e/tool-sidebar.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * E2E tests for #232: Tool output sidebar panel.
+ *
+ * Verifies that tool call cards show a "상세" button that opens a sidebar,
+ * and the sidebar displays tool args/result with proper formatting.
+ */
+import { test, expect } from "./helpers/fixtures";
+
+test.describe("Tool Output Sidebar (#232)", () => {
+  test("shows 상세 button on completed tool calls and opens sidebar", async ({ mockGateway }) => {
+    const page = await mockGateway({
+      historyMessages: [
+        { role: "user", content: "Read the file" },
+        {
+          role: "assistant",
+          content: "Here is the file content.",
+          toolCalls: [
+            {
+              callId: "call-1",
+              name: "Read",
+              status: "done",
+              args: JSON.stringify({ path: "src/app.ts" }),
+              result: JSON.stringify({ content: "const app = express();" }),
+            },
+          ],
+        },
+      ],
+    });
+
+    // Wait for tool card to render
+    const toolCard = page.locator("text=Read");
+    await expect(toolCard.first()).toBeVisible({ timeout: 5000 });
+
+    // Click the 상세 button
+    const detailBtn = page.locator("button", { hasText: "상세" });
+    await expect(detailBtn).toBeVisible();
+    await detailBtn.click();
+
+    // Sidebar should be visible with tool details
+    await expect(page.getByLabel("사이드바 닫기")).toBeVisible();
+    await expect(page.getByText("Arguments")).toBeVisible();
+    await expect(page.getByText("Result")).toBeVisible();
+  });
+
+  test("closes sidebar with ESC key", async ({ mockGateway }) => {
+    const page = await mockGateway({
+      historyMessages: [
+        { role: "user", content: "Search" },
+        {
+          role: "assistant",
+          content: "Found results.",
+          toolCalls: [
+            {
+              callId: "call-2",
+              name: "web_search",
+              status: "done",
+              args: JSON.stringify({ query: "test" }),
+              result: "Some search results here",
+            },
+          ],
+        },
+      ],
+    });
+
+    // Open sidebar
+    const detailBtn = page.locator("button", { hasText: "상세" });
+    await expect(detailBtn).toBeVisible({ timeout: 5000 });
+    await detailBtn.click();
+    await expect(page.getByLabel("사이드바 닫기")).toBeVisible();
+
+    // Press ESC to close
+    await page.keyboard.press("Escape");
+    await expect(page.getByLabel("사이드바 닫기")).not.toBeVisible();
+  });
+});

--- a/apps/web/src/__tests__/stream-segments.test.ts
+++ b/apps/web/src/__tests__/stream-segments.test.ts
@@ -1,0 +1,200 @@
+/**
+ * stream-segments.test.ts — Tests for #231 buildStreamSegments()
+ *
+ * Verifies that text↔tool interleave order is preserved when building
+ * MessageSegment[] from the 3-buffer streaming state.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createRef } from "react";
+import {
+  buildStreamSegments,
+  resetAllStreamRefs,
+  commitChatStreamToSegment,
+  type ToolStreamRefs,
+  type ToolStreamEntry,
+} from "@/lib/gateway/tool-stream";
+
+function createRefs(): ToolStreamRefs {
+  return {
+    chatStream: createRef() as any,
+    chatStreamId: createRef() as any,
+    chatStreamStartedAt: createRef() as any,
+    chatStreamSegments: createRef() as any,
+    toolStreamById: createRef() as any,
+    toolStreamOrder: createRef() as any,
+  };
+}
+
+function initRefs(refs: ToolStreamRefs) {
+  refs.chatStream.current = null;
+  refs.chatStreamId.current = null;
+  refs.chatStreamStartedAt.current = null;
+  refs.chatStreamSegments.current = [];
+  refs.toolStreamById.current = new Map();
+  refs.toolStreamOrder.current = [];
+}
+
+describe("buildStreamSegments (#231)", () => {
+  let refs: ToolStreamRefs;
+
+  beforeEach(() => {
+    refs = createRefs();
+    initRefs(refs);
+  });
+
+  it("returns empty array when no streaming state", () => {
+    expect(buildStreamSegments(refs)).toEqual([]);
+  });
+
+  it("returns single text segment for text-only stream", () => {
+    refs.chatStream.current = "Hello world";
+    const segments = buildStreamSegments(refs);
+    expect(segments).toEqual([{ type: "text", text: "Hello world" }]);
+  });
+
+  it("preserves text → tool → text interleave order", () => {
+    // Simulate: "Analyzing..." → tool:read_file → "Found the issue."
+    const baseTs = 1000;
+
+    // Text A committed before tool
+    refs.chatStreamSegments.current = [
+      { text: "Analyzing the code...", ts: baseTs },
+    ];
+
+    // Tool call started after text A
+    const toolEntry: ToolStreamEntry = {
+      toolCallId: "call-1",
+      name: "read_file",
+      args: '{"path":"src/app.ts"}',
+      output: "file contents...",
+      startedAt: baseTs + 100,
+      updatedAt: baseTs + 200,
+    };
+    refs.toolStreamById.current.set("call-1", toolEntry);
+    refs.toolStreamOrder.current = ["call-1"];
+
+    // Text B is current (uncommitted) chatStream
+    refs.chatStream.current = "Found the issue.";
+
+    const segments = buildStreamSegments(refs);
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toEqual({ type: "text", text: "Analyzing the code..." });
+    expect(segments[1].type).toBe("tool");
+    expect((segments[1] as any).toolCall.name).toBe("read_file");
+    expect(segments[2]).toEqual({ type: "text", text: "Found the issue." });
+  });
+
+  it("preserves text → tool1 → text → tool2 → text order", () => {
+    const baseTs = 1000;
+
+    refs.chatStreamSegments.current = [
+      { text: "Step 1", ts: baseTs },
+      { text: "Step 2", ts: baseTs + 300 },
+    ];
+
+    const tool1: ToolStreamEntry = {
+      toolCallId: "c1", name: "search", startedAt: baseTs + 100, updatedAt: baseTs + 200,
+    };
+    const tool2: ToolStreamEntry = {
+      toolCallId: "c2", name: "edit", startedAt: baseTs + 400, updatedAt: baseTs + 500,
+    };
+    refs.toolStreamById.current.set("c1", tool1);
+    refs.toolStreamById.current.set("c2", tool2);
+    refs.toolStreamOrder.current = ["c1", "c2"];
+
+    refs.chatStream.current = "All done.";
+
+    const segments = buildStreamSegments(refs);
+    expect(segments).toHaveLength(5);
+    expect(segments[0]).toEqual({ type: "text", text: "Step 1" });
+    expect(segments[1].type).toBe("tool");
+    expect((segments[1] as any).toolCall.name).toBe("search");
+    expect(segments[2]).toEqual({ type: "text", text: "Step 2" });
+    expect(segments[3].type).toBe("tool");
+    expect((segments[3] as any).toolCall.name).toBe("edit");
+    expect(segments[4]).toEqual({ type: "text", text: "All done." });
+  });
+
+  it("handles tool-only response (no text)", () => {
+    const tool: ToolStreamEntry = {
+      toolCallId: "c1", name: "exec", startedAt: 1000, updatedAt: 1100,
+    };
+    refs.toolStreamById.current.set("c1", tool);
+    refs.toolStreamOrder.current = ["c1"];
+
+    const segments = buildStreamSegments(refs);
+    expect(segments).toHaveLength(1);
+    expect(segments[0].type).toBe("tool");
+  });
+
+  it("filters empty/whitespace text segments", () => {
+    refs.chatStreamSegments.current = [
+      { text: "  ", ts: 1000 },
+      { text: "Valid text", ts: 2000 },
+    ];
+    refs.chatStream.current = "   ";
+
+    const segments = buildStreamSegments(refs);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toEqual({ type: "text", text: "Valid text" });
+  });
+
+  it("handles consecutive tools without text between them", () => {
+    const tool1: ToolStreamEntry = {
+      toolCallId: "c1", name: "read", startedAt: 1000, updatedAt: 1100,
+    };
+    const tool2: ToolStreamEntry = {
+      toolCallId: "c2", name: "write", startedAt: 1200, updatedAt: 1300,
+    };
+    refs.toolStreamById.current.set("c1", tool1);
+    refs.toolStreamById.current.set("c2", tool2);
+    refs.toolStreamOrder.current = ["c1", "c2"];
+
+    const segments = buildStreamSegments(refs);
+    expect(segments).toHaveLength(2);
+    expect(segments[0].type).toBe("tool");
+    expect(segments[1].type).toBe("tool");
+  });
+
+  it("marks running tools correctly", () => {
+    const tool: ToolStreamEntry = {
+      toolCallId: "c1", name: "exec", startedAt: 1000, updatedAt: 1000,
+      // no output = running
+    };
+    refs.toolStreamById.current.set("c1", tool);
+    refs.toolStreamOrder.current = ["c1"];
+
+    const segments = buildStreamSegments(refs);
+    expect((segments[0] as any).toolCall.status).toBe("running");
+  });
+
+  it("integrates with commitChatStreamToSegment", () => {
+    // Simulate streaming: text arrives, then tool starts
+    refs.chatStream.current = "Let me check...";
+    refs.chatStreamStartedAt.current = 1000;
+    refs.chatStreamId.current = "stream-1";
+
+    // Commit before tool start
+    commitChatStreamToSegment(refs);
+
+    // Fix the committed segment's timestamp to be before the tool
+    refs.chatStreamSegments.current[0].ts = 1000;
+
+    // Now add tool
+    const tool: ToolStreamEntry = {
+      toolCallId: "c1", name: "read_file", startedAt: 1100, updatedAt: 1200,
+      output: "contents",
+    };
+    refs.toolStreamById.current.set("c1", tool);
+    refs.toolStreamOrder.current = ["c1"];
+
+    // New text after tool
+    refs.chatStream.current = "Here's what I found.";
+
+    const segments = buildStreamSegments(refs);
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toEqual({ type: "text", text: "Let me check..." });
+    expect(segments[1].type).toBe("tool");
+    expect(segments[2]).toEqual({ type: "text", text: "Here's what I found." });
+  });
+});

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -1,7 +1,7 @@
 
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { ArrowUp, Paperclip, Square, X, Reply, History, Trash2 } from "lucide-react";
+import { ArrowUp, Paperclip, Square, X, Reply, History, Trash2, ListPlus } from "lucide-react";
 
 import { cn, windowStoragePrefix } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -646,13 +646,20 @@ export function ChatInput({
             ) : (
               <Button
                 type="button"
-                size="icon-sm"
-                className="shrink-0 rounded-lg transition-opacity min-w-[44px] min-h-[44px] md:min-w-0 md:min-h-0"
-                aria-label="전송"
+                size={streaming ? "sm" : "icon-sm"}
+                className={`shrink-0 rounded-lg transition-opacity min-w-[44px] min-h-[44px] md:min-w-0 md:min-h-0 ${streaming ? "gap-1 px-2.5" : ""}`}
+                aria-label={streaming ? "대기열에 추가" : "전송"}
                 onClick={handleSend}
                 disabled={disabled || !canSend}
               >
-                <ArrowUp className="size-4" strokeWidth={2.5} />
+                {streaming ? (
+                  <>
+                    <ListPlus className="size-3.5" />
+                    <span className="text-[11px] hidden sm:inline">대기열</span>
+                  </>
+                ) : (
+                  <ArrowUp className="size-4" strokeWidth={2.5} />
+                )}
               </Button>
             )}
           </div>

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -28,6 +28,8 @@ import { TopicHistory } from "./topic-history";
 import { TopicNameDialog } from "./topic-name-dialog";
 import { resolveInitialSessionState, getRememberedSessionForAgent } from "@/lib/session-continuity";
 import { platform } from "@/lib/platform";
+import { ToolSidebar } from "./tool-sidebar";
+import type { ToolCall } from "@intelli-claw/shared";
 
 export interface ChatPanelProps {
   /** Show header controls (agent selector, session switcher) */
@@ -43,6 +45,8 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
 
   const [sessionKey, setSessionKeyRaw] = useState<string | undefined>(undefined);
   const [agentId, setAgentId] = useState<string>(import.meta.env.VITE_DEFAULT_AGENT || "default");
+  // #232: Tool sidebar state
+  const [sidebarTool, setSidebarTool] = useState<ToolCall | null>(null);
 
   // Load persisted state on mount (client only)
   useEffect(() => {
@@ -59,6 +63,7 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
 
   const setSessionKey = useCallback((key: string | undefined) => {
     setSessionKeyRaw(key);
+    setSidebarTool(null); // #232: Close sidebar on session switch
     if (typeof window !== "undefined") {
       if (key) {
         localStorage.setItem(`${storagePrefix}sessionKey`, key);
@@ -863,24 +868,35 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
         />
       )}
 
-      {/* Messages */}
-      <DropZone onDrop={addFiles}>
-        <MessageList
-          messages={messages}
-          loading={loading}
-          streaming={streaming}
-          onCancelQueued={cancelQueued}
-          agentId={currentAgentId}
-          agentStatus={agentStatus}
-          onOpenTopicHistory={() => setTopicHistoryOpen(true)}
-          onReply={setReplyTo}
-          onClearMessages={() => {
-            if (window.confirm("채팅 내용을 모두 비우시겠습니까?")) {
-              clearMessages();
-            }
-          }}
-        />
-      </DropZone>
+      {/* Messages + Tool Sidebar */}
+      <div className="flex flex-1 min-h-0 overflow-hidden">
+        <DropZone onDrop={addFiles}>
+          <MessageList
+            messages={messages}
+            loading={loading}
+            streaming={streaming}
+            onCancelQueued={cancelQueued}
+            agentId={currentAgentId}
+            agentStatus={agentStatus}
+            onOpenTopicHistory={() => setTopicHistoryOpen(true)}
+            onReply={setReplyTo}
+            onToolClick={setSidebarTool}
+            onClearMessages={() => {
+              if (window.confirm("채팅 내용을 모두 비우시겠습니까?")) {
+                clearMessages();
+              }
+            }}
+          />
+        </DropZone>
+        {/* #232: Tool output sidebar */}
+        {sidebarTool && (
+          <ToolSidebar
+            toolCall={sidebarTool}
+            onClose={() => setSidebarTool(null)}
+            overlay={isMobile}
+          />
+        )}
+      </div>
 
       {/* Input with integrated toolbar */}
       <ChatInput

--- a/apps/web/src/components/chat/message-list.tsx
+++ b/apps/web/src/components/chat/message-list.tsx
@@ -10,6 +10,7 @@ import { MarkdownRenderer, MarkdownFilePreview } from "./markdown-renderer";
 import { ToolCallCard } from "./tool-call-card";
 import { ThinkingBlock } from "./thinking-block";
 import { HIDDEN_REPLY_RE, canBeReplyTarget, stripTrailingControlTokens, type DisplayMessage, type DisplayAttachment, type AgentStatus, type SystemInjectedType } from "@/lib/gateway/hooks";
+import type { ToolCall } from "@intelli-claw/shared";
 import { useShowThinking } from "@/lib/hooks/use-show-thinking";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
 import { groupMessages } from "@intelli-claw/shared";
@@ -118,6 +119,7 @@ export function MessageList({
   agentStatus,
   onOpenTopicHistory,
   onReply,
+  onToolClick,
 }: {
   messages: DisplayMessage[];
   loading: boolean;
@@ -127,6 +129,7 @@ export function MessageList({
   agentStatus?: AgentStatus;
   onOpenTopicHistory?: () => void;
   onReply?: (msg: DisplayMessage) => void;
+  onToolClick?: (tc: ToolCall) => void;
 }) {
   const PAGE_SIZE = 50;
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -568,6 +571,7 @@ export function MessageList({
                 focused={focusedIdx === idx}
                 selected={selectedIndices.has(idx)}
                 onReply={onReply}
+                onToolClick={onToolClick}
                 showThinking={showThinking}
               />
             );
@@ -765,8 +769,8 @@ function ReplyButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-const MessageBubble = React.memo(React.forwardRef<HTMLDivElement, { message: DisplayMessage; showAvatar?: boolean; showTimestamp?: boolean; onCancel?: (id: string) => void; agentId?: string; agentStatus?: AgentStatus; focused?: boolean; selected?: boolean; onReply?: (msg: DisplayMessage) => void; showThinking?: boolean }>(
-  function MessageBubble({ message, showAvatar = true, showTimestamp = true, onCancel, agentId, agentStatus, focused, selected, onReply, showThinking = true }, ref) {
+const MessageBubble = React.memo(React.forwardRef<HTMLDivElement, { message: DisplayMessage; showAvatar?: boolean; showTimestamp?: boolean; onCancel?: (id: string) => void; agentId?: string; agentStatus?: AgentStatus; focused?: boolean; selected?: boolean; onReply?: (msg: DisplayMessage) => void; showThinking?: boolean; onToolClick?: (tc: ToolCall) => void }>(
+  function MessageBubble({ message, showAvatar = true, showTimestamp = true, onCancel, agentId, agentStatus, focused, selected, onReply, showThinking = true, onToolClick }, ref) {
   const isUser = message.role === "user";
   const isSystem = message.role === "system";
   const isQueued = message.queued;
@@ -905,12 +909,27 @@ const MessageBubble = React.memo(React.forwardRef<HTMLDivElement, { message: Dis
             {showThinking && message.thinking && message.thinking.length > 0 && (
               <ThinkingBlock thinking={message.thinking} streaming={message.streaming} />
             )}
-            {message.toolCalls.length > 0 && (
-              <div className="mb-2">
-                {message.toolCalls.map((tc) => (
-                  <ToolCallCard key={tc.callId} toolCall={tc} />
-                ))}
+            {/* #231: Interleaved segments (text↔tool in order) */}
+            {message.segments && message.segments.length > 0 ? (
+              <div className="mb-2 space-y-2 min-w-0 overflow-hidden">
+                {message.segments.map((seg, i) =>
+                  seg.type === "text" ? (
+                    <MarkdownRenderer key={`seg-text-${i}`} content={seg.text} />
+                  ) : (
+                    <ToolCallCard key={seg.toolCall.callId} toolCall={seg.toolCall} onViewDetail={onToolClick} />
+                  )
+                )}
               </div>
+            ) : (
+              <>
+                {message.toolCalls.length > 0 && (
+                  <div className="mb-2">
+                    {message.toolCalls.map((tc) => (
+                      <ToolCallCard key={tc.callId} toolCall={tc} onViewDetail={onToolClick} />
+                    ))}
+                  </div>
+                )}
+              </>
             )}
             {/* Assistant attachments (images + files) */}
             {message.attachments && message.attachments.length > 0 && (
@@ -966,9 +985,10 @@ const MessageBubble = React.memo(React.forwardRef<HTMLDivElement, { message: Dis
                 })}
               </div>
             )}
-            {message.content && (() => {
-              return message.content ? <MarkdownRenderer content={message.content} /> : null;
-            })()}
+            {/* Render content only when not using segments (segments already include text) */}
+            {!message.segments && message.content && (
+              <MarkdownRenderer content={message.content} />
+            )}
             {message.streaming && (
               <span className="inline-block h-4 w-1.5 animate-pulse rounded-sm bg-primary" />
             )}
@@ -1007,6 +1027,7 @@ export function messageBubbleAreEqual(
     && (pm.toolCalls?.length ?? 0) === (nm.toolCalls?.length ?? 0)
     && (pm.attachments?.length ?? 0) === (nm.attachments?.length ?? 0)
     && (pm.thinking?.length ?? 0) === (nm.thinking?.length ?? 0)
+    && (pm.segments?.length ?? 0) === (nm.segments?.length ?? 0)
     && prev.focused === next.focused
     && prev.selected === next.selected
     && prev.agentId === next.agentId

--- a/apps/web/src/components/chat/tool-call-card.tsx
+++ b/apps/web/src/components/chat/tool-call-card.tsx
@@ -99,7 +99,7 @@ function ResultPreview({ result }: { result: string }) {
   );
 }
 
-export function ToolCallCard({ toolCall }: { toolCall: ToolCall }) {
+export function ToolCallCard({ toolCall, onViewDetail }: { toolCall: ToolCall; onViewDetail?: (tc: ToolCall) => void }) {
   const [expanded, setExpanded] = useState(false);
 
   // Resolve display info from registry
@@ -174,6 +174,15 @@ export function ToolCallCard({ toolCall }: { toolCall: ToolCall }) {
         <span className="text-xs text-foreground">{display.label}</span>
         {toolCall.status === "running" && (
           <span className="ml-auto text-xs text-muted-foreground">실행 중...</span>
+        )}
+        {onViewDetail && toolCall.result && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onViewDetail(toolCall); }}
+            className="ml-auto rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-zinc-600/40 hover:text-zinc-300 transition"
+            title="사이드바에서 상세 보기"
+          >
+            상세
+          </button>
         )}
       </button>
 

--- a/apps/web/src/components/chat/tool-sidebar.tsx
+++ b/apps/web/src/components/chat/tool-sidebar.tsx
@@ -1,0 +1,248 @@
+
+import { useEffect, useCallback, useState, useRef } from "react";
+import {
+  X, Copy, Check, Loader2, CheckCircle2, AlertCircle, Wrench,
+  Maximize2, Minimize2,
+} from "lucide-react";
+import { MarkdownRenderer } from "./markdown-renderer";
+import type { ToolCall } from "@intelli-claw/shared";
+import { resolveToolDisplay } from "@/lib/gateway/tool-display";
+
+interface ToolSidebarProps {
+  toolCall: ToolCall;
+  onClose: () => void;
+  /** Mobile overlay mode */
+  overlay?: boolean;
+}
+
+/** Format JSON with indentation, or return raw string */
+function formatJson(s: string): string {
+  try {
+    return JSON.stringify(JSON.parse(s), null, 2);
+  } catch {
+    return s;
+  }
+}
+
+/** Detect if string is valid JSON */
+function isJson(s: string): boolean {
+  try {
+    JSON.parse(s);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Wrap JSON in markdown code block for syntax highlighting */
+function formatResultForDisplay(result: string): { content: string; isJsonResult: boolean } {
+  const trimmed = result.trim();
+  if (isJson(trimmed)) {
+    const formatted = formatJson(trimmed);
+    return { content: "```json\n" + formatted + "\n```", isJsonResult: true };
+  }
+  return { content: trimmed, isJsonResult: false };
+}
+
+function CopyButton({ text, label }: { text: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {}
+  };
+  return (
+    <button
+      onClick={handleCopy}
+      className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-zinc-700/50 hover:text-zinc-300 transition"
+      title={`${label || "내용"} 복사`}
+    >
+      {copied ? <Check size={10} className="text-emerald-400" /> : <Copy size={10} />}
+      {copied ? "복사됨" : "복사"}
+    </button>
+  );
+}
+
+const MIN_WIDTH = 280;
+const MAX_WIDTH_PERCENT = 0.6;
+const STORAGE_KEY = "awf:tool-sidebar-width";
+
+function getStoredWidth(): number {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    return v ? Math.max(MIN_WIDTH, parseInt(v, 10)) : 420;
+  } catch {
+    return 420;
+  }
+}
+
+/**
+ * Tool output sidebar panel (#232).
+ * Shows full tool call details: args + result with syntax highlighting.
+ * Desktop: side panel with drag resize. Mobile: overlay modal.
+ */
+export function ToolSidebar({ toolCall, onClose, overlay }: ToolSidebarProps) {
+  const display = resolveToolDisplay(toolCall.name);
+  const [width, setWidth] = useState(getStoredWidth);
+  const draggingRef = useRef(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+  const lastClientXRef = useRef(0);
+
+  // ESC to close
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  // Drag resize handlers
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    draggingRef.current = true;
+    startXRef.current = e.clientX;
+    startWidthRef.current = width;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const handleMouseMove = (me: MouseEvent) => {
+      if (!draggingRef.current) return;
+      lastClientXRef.current = me.clientX;
+      const delta = startXRef.current - me.clientX; // drag left = wider
+      const maxWidth = window.innerWidth * MAX_WIDTH_PERCENT;
+      const newWidth = Math.min(maxWidth, Math.max(MIN_WIDTH, startWidthRef.current + delta));
+      setWidth(newWidth);
+    };
+
+    const handleMouseUp = () => {
+      draggingRef.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      // Persist final width (compute from last mousemove, not captured closure)
+      const finalDelta = startXRef.current - (lastClientXRef.current ?? startXRef.current);
+      const maxWidth = window.innerWidth * MAX_WIDTH_PERCENT;
+      const finalWidth = Math.min(maxWidth, Math.max(MIN_WIDTH, startWidthRef.current + finalDelta));
+      try { localStorage.setItem(STORAGE_KEY, String(Math.round(finalWidth))); } catch {}
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+  }, [width]);
+
+  const statusIcon =
+    toolCall.status === "running" ? (
+      <Loader2 size={14} className="animate-spin text-primary" />
+    ) : toolCall.status === "done" ? (
+      <CheckCircle2 size={14} className="text-emerald-400" />
+    ) : (
+      <AlertCircle size={14} className="text-destructive" />
+    );
+
+  const formattedArgs = toolCall.args ? formatJson(toolCall.args) : null;
+  const resultDisplay = toolCall.result ? formatResultForDisplay(toolCall.result) : null;
+
+  const content = (
+    <div className="flex h-full flex-col bg-zinc-900 border-l border-zinc-700/60">
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b border-zinc-700/60 px-3 py-2.5 shrink-0">
+        {statusIcon}
+        <Wrench size={14} className="text-muted-foreground" />
+        <span className="flex-1 text-sm font-medium text-zinc-200 truncate">{display.label}</span>
+        <button
+          onClick={onClose}
+          className="rounded p-1 text-zinc-500 hover:bg-zinc-700/50 hover:text-zinc-300 transition"
+          aria-label="사이드바 닫기"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      {/* Scrollable content */}
+      <div className="flex-1 overflow-y-auto px-3 py-3 space-y-4">
+        {/* Tool name + call ID */}
+        <div className="text-[11px] text-zinc-500 font-mono">
+          {toolCall.name}
+          {toolCall.callId && (
+            <span className="ml-2 text-zinc-600">({toolCall.callId.slice(0, 12)})</span>
+          )}
+        </div>
+
+        {/* Arguments */}
+        {formattedArgs && (
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-[11px] font-medium text-zinc-400 uppercase tracking-wider">Arguments</span>
+              <CopyButton text={formattedArgs} label="Arguments" />
+            </div>
+            <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-lg bg-zinc-800/60 p-3 text-xs text-zinc-300 font-mono border border-zinc-700/40">
+              {formattedArgs}
+            </pre>
+          </div>
+        )}
+
+        {/* Result */}
+        {resultDisplay && (
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-[11px] font-medium text-zinc-400 uppercase tracking-wider">Result</span>
+              <CopyButton text={toolCall.result!} label="Result" />
+            </div>
+            {resultDisplay.isJsonResult ? (
+              <div className="rounded-lg border border-zinc-700/40 overflow-hidden">
+                <div className="prose prose-sm prose-invert max-w-none [&_pre]:max-h-none [&_pre]:m-0 [&_pre]:rounded-none">
+                  <MarkdownRenderer content={resultDisplay.content} />
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-lg bg-zinc-800/60 border border-zinc-700/40 p-3">
+                <div className="prose prose-sm prose-invert max-w-none text-xs">
+                  <MarkdownRenderer content={resultDisplay.content} />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Running state */}
+        {toolCall.status === "running" && !toolCall.result && (
+          <div className="flex items-center gap-2 rounded-lg bg-primary/5 border border-primary/20 px-3 py-2.5 text-xs text-primary">
+            <Loader2 size={14} className="animate-spin" />
+            실행 중...
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  // Mobile: overlay modal
+  if (overlay) {
+    return (
+      <div className="fixed inset-0 z-50" role="dialog" aria-modal="true">
+        <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+        <div className="absolute inset-x-0 bottom-0 top-16 rounded-t-xl overflow-hidden shadow-2xl">
+          {content}
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: side panel with drag resize
+  return (
+    <div className="relative flex shrink-0 h-full" style={{ width }}>
+      {/* Drag resize handle */}
+      <div
+        onMouseDown={handleMouseDown}
+        className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors z-10"
+        title="드래그하여 너비 조절"
+      />
+      {content}
+    </div>
+  );
+}

--- a/apps/web/src/lib/gateway/hooks.tsx
+++ b/apps/web/src/lib/gateway/hooks.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode,
   type SetStateAction,
 } from "react";
+import { usePageVisibility } from "@/lib/hooks/use-page-visibility";
 import { getMimeType } from "@/lib/mime-types";
 import { windowStoragePrefix } from "@/lib/utils";
 import { validateMediaPath, sanitizeAttachmentPath } from "@/lib/platform/media-path";
@@ -15,6 +16,7 @@ import type {
   EventFrame,
   Session,
   ChatMessage,
+  ContentPart,
   ToolCall,
 } from "@intelli-claw/shared";
 
@@ -45,6 +47,9 @@ import {
   mergeConsecutiveAssistant,
   ChatStreamProcessor,
   stripTemplateVars,
+  buildStreamSegments,
+  extractThinking,
+  type MessageSegment,
 } from "@intelli-claw/shared";
 
 // Re-export everything from shared for backward compatibility
@@ -69,6 +74,7 @@ export {
   type SystemInjectedType,
   type ToolStreamRefs,
   type ToolStreamEntry,
+  type MessageSegment,
   HIDDEN_REPLY_RE,
   INTERNAL_PROMPT_RE,
   TRAILING_CONTROL_TOKEN_RE,
@@ -113,6 +119,44 @@ import {
 } from "./message-store";
 
 import { getTopicHistory } from "./topic-store";
+
+// --- Label Preservation (#216) ---
+
+export interface SessionLabelSnapshot {
+  key: string;
+  sessionId: string;
+  label?: string;
+}
+
+/**
+ * Detect session resets and determine which labels need restoring.
+ * Pure function extracted for testability (#216).
+ */
+export function detectLabelsToRestore(
+  trackedSessionIds: Map<string, string>,
+  preservedLabels: Map<string, string>,
+  sessions: SessionLabelSnapshot[],
+): Map<string, string> {
+  const labelsToRestore = new Map<string, string>();
+
+  for (const s of sessions) {
+    if (!s.key || !s.sessionId) continue;
+
+    if (s.label) {
+      preservedLabels.set(s.key, s.label);
+    }
+
+    const oldSessionId = trackedSessionIds.get(s.key);
+    if (oldSessionId && oldSessionId !== s.sessionId) {
+      const previousLabel = preservedLabels.get(s.key);
+      if (previousLabel && !s.label) {
+        labelsToRestore.set(s.key, previousLabel);
+      }
+    }
+  }
+
+  return labelsToRestore;
+}
 
 // --- Streaming Timeout Constants (#154, #264) ---
 // Exported for testing — values must stay in sync with startStreamingTimeout().
@@ -230,6 +274,7 @@ export function useSessions() {
   const trackedSessionIdsRef = useRef<Map<string, string>>(new Map());
   /** Preserve user-set labels across session resets (#216) */
   const preservedLabelsRef = useRef<Map<string, string>>(new Map());
+  const visible = usePageVisibility();
 
   const fetchSessions = useCallback(async () => {
     if (!client || state !== "connected") return;
@@ -238,30 +283,16 @@ export function useSessions() {
       const res = await client.request<{ sessions: Array<Record<string, unknown>> }>("sessions.list", { limit: 200 });
 
       // #216: Detect session resets and preserve labels BEFORE updating UI state.
-      // This ensures the UI never flashes an empty/wrong label on reset.
-      const labelsToRestore = new Map<string, string>();
-
-      for (const s of res?.sessions || []) {
-        const key = String(s.key || "");
-        const newSessionId = s.sessionId ? String(s.sessionId) : undefined;
-        if (!key || !newSessionId) continue;
-
-        const serverLabel = s.label ? String(s.label) : undefined;
-        const oldSessionId = trackedSessionIdsRef.current.get(key);
-
-        // Track non-empty labels so we can restore them if a reset clears them
-        if (serverLabel) {
-          preservedLabelsRef.current.set(key, serverLabel);
-        }
-
-        if (oldSessionId && oldSessionId !== newSessionId) {
-          // Session reset detected — check if label needs preservation
-          const previousLabel = preservedLabelsRef.current.get(key);
-          if (previousLabel && !serverLabel) {
-            labelsToRestore.set(key, previousLabel);
-          }
-        }
-      }
+      const sessionSnapshots: SessionLabelSnapshot[] = (res?.sessions || []).map((s) => ({
+        key: String(s.key || ""),
+        sessionId: s.sessionId ? String(s.sessionId) : "",
+        label: s.label ? String(s.label) : undefined,
+      }));
+      const labelsToRestore = detectLabelsToRestore(
+        trackedSessionIdsRef.current,
+        preservedLabelsRef.current,
+        sessionSnapshots,
+      );
 
       const mapped = (res?.sessions || []).map((s) => {
         const key = String(s.key || "");
@@ -323,10 +354,24 @@ export function useSessions() {
           const existing = await getCurrentSessionId(key);
           if (!existing || existing !== newSessionId) {
             if (existing) {
+              // #216: On first poll after refresh, if session reset happened while offline,
+              // try to recover label from IndexedDB before marking the old session ended.
+              const serverLabel = s.label ? String(s.label) : undefined;
+              if (!serverLabel) {
+                try {
+                  const topics = await getTopicHistory(key);
+                  const prevTopic = topics.find((t: any) => t.sessionId === existing);
+                  if (prevTopic?.label) {
+                    labelsToRestore.set(key, prevTopic.label);
+                    preservedLabelsRef.current.set(key, prevTopic.label);
+                    client.request("sessions.patch", { key, label: prevTopic.label }).catch(() => {});
+                  }
+                } catch { /* best-effort */ }
+              }
               markSessionEnded(key, existing).catch(() => {});
             }
             trackSessionId(key, newSessionId, {
-              label: s.label ? String(s.label) : undefined,
+              label: s.label ? String(s.label) : labelsToRestore.get(key),
             }).catch(() => {});
           }
         }
@@ -371,6 +416,14 @@ export function useSessions() {
     });
     return unsub;
   }, [client, refreshThrottled]);
+
+  // #260: Only run 15s polling when page is visible; refresh immediately on becoming visible
+  useEffect(() => {
+    if (state !== "connected" || !visible) return;
+    refreshThrottled();
+    const id = setInterval(() => { refreshThrottled(); }, 15000);
+    return () => clearInterval(id);
+  }, [state, visible, refreshThrottled]);
 
   const patchSession = useCallback((key: string, patch: Record<string, unknown>) => {
     setSessions((prev) => prev.map((s) => (s.key === key ? { ...s, ...patch } : s)));
@@ -563,6 +616,17 @@ export function truncateForPreview(content: string, maxLen = 100): string {
   return oneLine.slice(0, maxLen - 1) + "…";
 }
 
+/**
+ * Extract thinking blocks from message content (#222).
+ * Wraps extractThinking from shared.
+ */
+export function extractThinkingFromContent(
+  content: string | ContentPart[] | Array<Record<string, unknown>>,
+): { thinking: Array<{ text: string }>; cleanContent: string } {
+  const result = extractThinking(content as string | ContentPart[]);
+  return { thinking: result.thinking, cleanContent: result.cleanContent };
+}
+
 /** Check if a message can be used as a reply target */
 export function canBeReplyTarget(msg: DisplayMessage): boolean {
   if (msg.role === "system" || msg.role === "session-boundary") return false;
@@ -611,6 +675,8 @@ export function useChat(sessionKey?: string) {
   const loadHistoryRef = useRef<(() => void) | null>(null);
   // #155: Track recently finalized stream IDs so loadHistory can skip duplicates
   const finalizedStreamIdsRef = useRef<Set<string>>(new Set());
+  // #155 / #218: Track finalized stream content for robust matching
+  const finalizedStreamContentRef = useRef<Map<string, { contentKey: string; ts: number }>>(new Map());
   const messagesRef = useRef<DisplayMessage[]>([]);
   // Throttle streaming UI updates to once per animation frame
   const streamRafRef = useRef<number | null>(null);
@@ -877,6 +943,7 @@ export function useChat(sessionKey?: string) {
         }
         runIdRef.current = null;
         finalizedStreamIdsRef.current.clear();
+        finalizedStreamContentRef.current.clear();
       }
       // Clear the OLD session's pending stream, not the new one's.
       // This prevents wiping a snapshot that beforeunload saved for the new session.
@@ -982,13 +1049,26 @@ export function useChat(sessionKey?: string) {
           let textContent = '';
           const imgAttachments: DisplayAttachment[] = [];
 
+          // #222: Extract thinking blocks from content
+          let thinkingBlocks: Array<{ text: string }> = [];
+          const orderedSegments: MessageSegment[] = [];
+
           if (typeof m.content === 'string') {
-            textContent = m.content;
+            const extracted = extractThinkingFromContent(m.content);
+            thinkingBlocks = extracted.thinking;
+            textContent = extracted.thinking.length > 0
+              ? extracted.cleanContent
+              : m.content;
           } else if (Array.isArray(m.content)) {
             const parts = m.content as Array<Record<string, unknown>>;
             const hasToolUse = parts.some(p => p.type === 'tool_use');
+
+            // Extract thinking blocks first
+            const extracted = extractThinkingFromContent(parts);
+            thinkingBlocks = extracted.thinking;
+
             for (const p of parts) {
-              // #249: Skip thinking content blocks — strip from display
+              // #222: Skip thinking — already extracted above
               if (p.type === 'thinking') continue;
               if (p.type === 'text' && typeof p.text === 'string') {
                 if (hasToolUse && m.role === 'assistant') {
@@ -998,6 +1078,24 @@ export function useChat(sessionKey?: string) {
                   if (!hasMedia && text.length < 100 && !text.includes('\n')) continue;
                 }
                 textContent += p.text;
+                // #231: Add text segment
+                if ((p.text as string).trim()) {
+                  orderedSegments.push({ type: "text", text: p.text as string });
+                }
+              } else if (p.type === 'tool_use') {
+                // #231: Add tool segment from content block
+                const toolId = (p.id as string) || `tool-${orderedSegments.length}`;
+                const toolName = (p.name as string) || 'unknown';
+                orderedSegments.push({
+                  type: "tool",
+                  toolCall: {
+                    callId: toolId,
+                    name: toolName,
+                    args: p.input ? JSON.stringify(p.input) : undefined,
+                    status: "done" as const,
+                    result: undefined,
+                  },
+                });
               } else if (p.type === 'image_url' || p.type === 'image') {
                 let url: string | undefined;
                 if (typeof p.image_url === 'object' && p.image_url) {
@@ -1070,6 +1168,8 @@ export function useChat(sessionKey?: string) {
             toolCalls: m.toolCalls || [],
             attachments: allAttachments.length > 0 ? allAttachments : undefined,
             systemType: systemType ?? undefined,
+            thinking: thinkingBlocks.length > 0 ? thinkingBlocks : undefined,
+            segments: orderedSegments.length > 1 ? orderedSegments : undefined,
           };
         })
         .filter((m) => {
@@ -1285,19 +1385,31 @@ export function useChat(sessionKey?: string) {
       }
       mergedMsgs = mergeLiveStreamingIntoHistory(mergedMsgs, liveStreaming);
 
-      // #155: Remove finalized stream messages that now have a gateway equivalent.
-      // After finalizeActiveStream, both the finalized msg (stream-...) and the
-      // gateway version (hist-N) can coexist. Remove the stream version if
-      // a gateway message with matching content already exists.
+      // #155 / #218: Remove finalized stream messages that now have a gateway equivalent.
+      // Uses both exact ID matching and content-based fuzzy matching for robustness.
       if (finalizedStreamIdsRef.current.size > 0 && dedupedHistMsgs.length > 0) {
-        const gwContentKeys = new Set(
-          dedupedHistMsgs.map((m) => `${m.role}:${normalizeContentForDedup(m.content)}`),
-        );
+        const gwEntries = dedupedHistMsgs.map((m) => ({
+          role: m.role,
+          contentKey: normalizeContentForDedup(m.content),
+          ts: new Date(m.timestamp).getTime(),
+        }));
         mergedMsgs = mergedMsgs.filter((m) => {
           if (!finalizedStreamIdsRef.current.has(m.id)) return true;
-          // Keep if no gateway equivalent exists (gateway hasn't caught up yet)
-          const key = `${m.role}:${normalizeContentForDedup(m.content)}`;
-          return !gwContentKeys.has(key);
+          // Exact content match
+          const key = normalizeContentForDedup(m.content);
+          if (gwEntries.some((g) => g.role === m.role && g.contentKey === key)) return false;
+          // #218: Fuzzy match — prefix (first 80 chars) + timestamp proximity (<30s)
+          const finalized = finalizedStreamContentRef.current.get(m.id);
+          if (finalized) {
+            const prefix = finalized.contentKey.slice(0, 80);
+            const fuzzyMatch = gwEntries.some((g) =>
+              g.role === m.role &&
+              Math.abs(g.ts - finalized.ts) < 30_000 &&
+              g.contentKey.slice(0, 80) === prefix
+            );
+            if (fuzzyMatch) return false;
+          }
+          return true;
         });
       }
 
@@ -1531,11 +1643,19 @@ export function useChat(sessionKey?: string) {
         requestHistoryReload: () => loadHistoryRef.current?.(),
         onPersistPendingStream: () => persistPendingStream(),
         onClearPersistedStream: () => clearPersistedPendingStream(),
-        onStreamFinalized: (streamId, content, toolCalls) => {
-          // #155: Record finalized stream ID so loadHistory can skip duplicates
+        onStreamFinalized: (streamId, content, toolCalls, segments, thinking) => {
+          // #155 / #218: Record finalized stream ID + content for robust dedup
           finalizedStreamIdsRef.current.add(streamId);
-          // Auto-expire after 30s to prevent unbounded growth
-          setTimeout(() => finalizedStreamIdsRef.current.delete(streamId), 30_000);
+          const finalContentKey = normalizeContentForDedup(content);
+          finalizedStreamContentRef.current.set(streamId, {
+            contentKey: finalContentKey,
+            ts: Date.now(),
+          });
+          // Auto-expire after 60s (#218: slow loadHistory could arrive after TTL)
+          setTimeout(() => {
+            finalizedStreamIdsRef.current.delete(streamId);
+            finalizedStreamContentRef.current.delete(streamId);
+          }, 60_000);
           // Save finalized message to local store
           const saveKey = boundSessionKey;
           if (saveKey && !HIDDEN_REPLY_RE.test(content.trim())) {
@@ -1546,6 +1666,9 @@ export function useChat(sessionKey?: string) {
               content,
               timestamp: new Date().toISOString(),
               toolCalls,
+              streaming: false,
+              ...(thinking ? { thinking } : {}),
+              ...(segments && segments.length > 0 ? { segments } : {}),
             }]).catch(() => {});
           }
         },

--- a/apps/web/src/lib/gateway/tool-stream.ts
+++ b/apps/web/src/lib/gateway/tool-stream.ts
@@ -1,0 +1,13 @@
+// Re-export from shared for backward compatibility
+export {
+  type ToolStreamRefs,
+  type ToolStreamEntry,
+  type MessageSegment,
+  createToolStreamRefs,
+  resetAllStreamRefs,
+  commitChatStreamToSegment,
+  hasActiveStream,
+  buildStreamContent,
+  buildStreamToolCalls,
+  buildStreamSegments,
+} from "@intelli-claw/shared";

--- a/packages/shared/src/gateway/chat-stream-processor.ts
+++ b/packages/shared/src/gateway/chat-stream-processor.ts
@@ -17,6 +17,7 @@ import type {
   ToolStreamRefs,
   ToolStreamEntry,
 } from "./chat-stream-types";
+import type { MessageSegment } from "./chat-stream-types";
 import {
   createToolStreamRefs,
   resetAllStreamRefs,
@@ -24,6 +25,7 @@ import {
   hasActiveStream,
   buildStreamContent,
   buildStreamToolCalls,
+  buildStreamSegments,
 } from "./tool-stream";
 import {
   HIDDEN_REPLY_RE,
@@ -56,6 +58,8 @@ export interface ChatStreamCallbacks {
     streamId: string,
     content: string,
     toolCalls: ToolCall[],
+    segments?: MessageSegment[],
+    thinking?: Array<{ text: string }>,
   ) => void;
   /**
    * Optional: transform final content before display (web: stripTemplateVars + extractMediaAttachments).
@@ -93,37 +97,41 @@ export interface ChatStreamProcessorConfig {
   timeoutMs?: number;
 }
 
-// ── Helper: extract text from chat delta payload ──
+// ── Helper: extract text and thinking from chat delta payload ──
 
-function extractDeltaText(
+function extractDeltaTextAndThinking(
   chatPayload: Record<string, unknown>,
-): string {
+): { text: string; thinking: Array<{ text: string }> } {
+  const thinking: Array<{ text: string }> = [];
   // Primary: payload.message with ContentPart[] (OpenClaw protocol)
   const chatMsg = chatPayload.message as
     | Record<string, unknown>
     | undefined;
   if (chatMsg) {
     if (typeof chatMsg.content === "string") {
-      return chatMsg.content;
+      return { text: chatMsg.content, thinking };
     }
     if (Array.isArray(chatMsg.content)) {
       let text = "";
       for (const p of chatMsg.content as Array<
         Record<string, unknown>
       >) {
-        if (p.type === "thinking") continue;
+        if (p.type === "thinking" && typeof p.text === "string") {
+          thinking.push({ text: p.text });
+          continue;
+        }
         if (p.type === "text" && typeof p.text === "string") {
           text += p.text;
         }
       }
-      return text;
+      return { text, thinking };
     }
   }
   // Fallback: payload.text (older gateway versions)
   if (typeof chatPayload.text === "string") {
-    return chatPayload.text as string;
+    return { text: chatPayload.text as string, thinking };
   }
-  return "";
+  return { text: "", thinking };
 }
 
 // ── Helper: build a final event dedup key ──
@@ -158,6 +166,8 @@ export class ChatStreamProcessor {
   private streamIdCounter = 0;
   private runId: string | null = null;
   private aborted = false;
+  /** #222: Accumulated thinking blocks during streaming */
+  private thinkingBlocks: Array<{ text: string }> = [];
 
   // Deferred history reload gate
   private pendingHistoryReload = false;
@@ -234,6 +244,7 @@ export class ChatStreamProcessor {
     this.pendingHistoryReload = false;
     this.finalizedEventKeys.clear();
     this.streamIdCounter = 0;
+    this.thinkingBlocks = [];
   }
 
   /** Clean up timers. Call when disposing. */
@@ -265,8 +276,21 @@ export class ChatStreamProcessor {
   }
 
   private handleChatDelta(chatPayload: Record<string, unknown>): void {
-    const text = extractDeltaText(chatPayload);
-    if (!text) return;
+    const { text, thinking } = extractDeltaTextAndThinking(chatPayload);
+
+    // #222: Accumulate thinking blocks
+    if (thinking.length > 0) {
+      this.thinkingBlocks = thinking;
+    }
+
+    if (!text) {
+      // Show thinking indicator even without text content
+      if (thinking.length > 0) {
+        this.cb.onStreamingChange(true);
+        this.cb.onAgentStatusChange({ phase: "thinking" });
+      }
+      return;
+    }
 
     // First suppress check: raw incoming text
     if (shouldSuppressStreamingPreview(text)) return;
@@ -298,6 +322,8 @@ export class ChatStreamProcessor {
     }
 
     const snapTools = buildStreamToolCalls(this.streamRefs);
+    const snapSegments = buildStreamSegments(this.streamRefs);
+    const snapThinking = this.thinkingBlocks.length > 0 ? [...this.thinkingBlocks] : undefined;
     const msg: DisplayMessage = {
       id: snapId,
       role: "assistant",
@@ -305,6 +331,8 @@ export class ChatStreamProcessor {
       timestamp: new Date().toISOString(),
       toolCalls: snapTools,
       streaming: true,
+      ...(snapSegments.length > 0 ? { segments: snapSegments } : {}),
+      ...(snapThinking ? { thinking: snapThinking } : {}),
     };
 
     this.cb.onMessagesUpdate((prev) => {
@@ -446,6 +474,8 @@ export class ChatStreamProcessor {
     const snapId = this.streamRefs.chatStreamId.current;
     const snapContent = buildStreamContent(this.streamRefs);
     const snapTools = buildStreamToolCalls(this.streamRefs);
+    const snapSegments = buildStreamSegments(this.streamRefs);
+    const snapThinking = this.thinkingBlocks.length > 0 ? [...this.thinkingBlocks] : undefined;
 
     this.cb.onMessagesUpdate((prev) => {
       const idx = prev.findIndex((m) => m.id === snapId);
@@ -456,6 +486,8 @@ export class ChatStreamProcessor {
         timestamp: new Date().toISOString(),
         toolCalls: snapTools,
         streaming: true,
+        ...(snapSegments.length > 0 ? { segments: snapSegments } : {}),
+        ...(snapThinking ? { thinking: snapThinking } : {}),
       };
       if (idx >= 0) {
         const next = [...prev];
@@ -484,11 +516,16 @@ export class ChatStreamProcessor {
       const snapId = this.streamRefs.chatStreamId.current;
       if (snapId) {
         const snapTools = buildStreamToolCalls(this.streamRefs);
+        const snapSegments = buildStreamSegments(this.streamRefs);
         this.cb.onMessagesUpdate((prev) => {
           const idx = prev.findIndex((m) => m.id === snapId);
           if (idx >= 0) {
             const next = [...prev];
-            next[idx] = { ...next[idx], toolCalls: snapTools };
+            next[idx] = {
+              ...next[idx],
+              toolCalls: snapTools,
+              ...(snapSegments.length > 0 ? { segments: snapSegments } : {}),
+            };
             return next;
           }
           return prev;
@@ -565,6 +602,8 @@ export class ChatStreamProcessor {
       buildStreamContent(this.streamRefs),
     );
     const finalToolCalls = buildStreamToolCalls(this.streamRefs);
+    const finalSegments = buildStreamSegments(this.streamRefs);
+    const finalThinking = this.thinkingBlocks.length > 0 ? [...this.thinkingBlocks] : undefined;
 
     // Platform-specific content transform (web: stripTemplateVars + extractMediaAttachments)
     let finalAttachments: DisplayMessage["attachments"];
@@ -581,6 +620,11 @@ export class ChatStreamProcessor {
     } else {
       this.cb.onMessagesUpdate((prev) => {
         const idx = prev.findIndex((m) => m.id === finalId);
+        const extras = {
+          ...(finalAttachments ? { attachments: finalAttachments } : {}),
+          ...(finalThinking ? { thinking: finalThinking } : {}),
+          ...(finalSegments.length > 0 ? { segments: finalSegments } : {}),
+        };
         if (idx >= 0) {
           const next = [...prev];
           next[idx] = {
@@ -588,9 +632,7 @@ export class ChatStreamProcessor {
             content: finalContent,
             toolCalls: finalToolCalls,
             streaming: false,
-            ...(finalAttachments
-              ? { attachments: finalAttachments }
-              : {}),
+            ...extras,
           };
           return next;
         }
@@ -603,17 +645,16 @@ export class ChatStreamProcessor {
             timestamp: new Date().toISOString(),
             toolCalls: finalToolCalls,
             streaming: false,
-            ...(finalAttachments
-              ? { attachments: finalAttachments }
-              : {}),
+            ...extras,
           },
         ];
       });
 
-      this.cb.onStreamFinalized?.(finalId, finalContent, finalToolCalls);
+      this.cb.onStreamFinalized?.(finalId, finalContent, finalToolCalls, finalSegments, finalThinking);
     }
 
     resetAllStreamRefs(this.streamRefs);
+    this.thinkingBlocks = [];
     this.runId = null;
     this.cb.onRunIdChange(null);
     this.cb.onClearPersistedStream?.();

--- a/packages/shared/src/gateway/chat-stream-types.ts
+++ b/packages/shared/src/gateway/chat-stream-types.ts
@@ -51,7 +51,16 @@ export interface DisplayMessage {
   isError?: boolean;
   /** Local image URIs for user-sent attachments (mobile display only) */
   imageUris?: string[];
+  /** #222: Extracted thinking/reasoning blocks from the model */
+  thinking?: Array<{ text: string }>;
+  /** #231: Ordered segments preserving text↔tool interleave */
+  segments?: MessageSegment[];
 }
+
+/** #231: A single segment in an interleaved text↔tool response */
+export type MessageSegment =
+  | { type: "text"; text: string }
+  | { type: "tool"; toolCall: ToolCall };
 
 export type AgentStatus =
   | { phase: "idle" }

--- a/packages/shared/src/gateway/message-utils.ts
+++ b/packages/shared/src/gateway/message-utils.ts
@@ -187,6 +187,16 @@ export function mergeConsecutiveAssistant(
                 ...(m.attachments || []),
               ]
             : undefined,
+        // #222: Merge thinking blocks from consecutive assistant messages
+        thinking:
+          acc.thinking || m.thinking
+            ? [...(acc.thinking || []), ...(m.thinking || [])]
+            : undefined,
+        // #231: Merge segments from consecutive assistant messages
+        segments:
+          acc.segments || m.segments
+            ? [...(acc.segments || []), ...(m.segments || [])]
+            : undefined,
       };
     } else {
       if (accumulator) result.push(accumulator);

--- a/packages/shared/src/gateway/tool-stream.ts
+++ b/packages/shared/src/gateway/tool-stream.ts
@@ -16,7 +16,7 @@
  */
 
 import type { ToolCall } from "./protocol";
-import type { ToolStreamRefs, ToolStreamEntry } from "./chat-stream-types";
+import type { ToolStreamRefs, ToolStreamEntry, MessageSegment } from "./chat-stream-types";
 
 // ── Factory ────────────────────────────────────────────────────────────
 
@@ -85,6 +85,58 @@ export function buildStreamContent(refs: ToolStreamRefs): string {
   const currentText = refs.chatStream.current || "";
   const parts = [...segments.map((s) => s.text), currentText].filter(Boolean);
   return parts.join("\n\n");
+}
+
+/**
+ * #231: Build interleaved MessageSegment[] from segments + tool calls.
+ * Uses timestamps to reconstruct the original text↔tool order.
+ */
+export function buildStreamSegments(refs: ToolStreamRefs): MessageSegment[] {
+  const result: MessageSegment[] = [];
+
+  // Collect all items with timestamps for sorting
+  const items: Array<{ ts: number; segment: MessageSegment }> = [];
+
+  // Text segments (committed before tool calls)
+  for (const seg of refs.chatStreamSegments.current) {
+    if (seg.text.trim()) {
+      items.push({ ts: seg.ts, segment: { type: "text", text: seg.text } });
+    }
+  }
+
+  // Tool calls
+  for (const callId of refs.toolStreamOrder.current) {
+    const entry = refs.toolStreamById.current.get(callId);
+    if (entry) {
+      items.push({
+        ts: entry.startedAt,
+        segment: {
+          type: "tool",
+          toolCall: {
+            callId: entry.toolCallId,
+            name: entry.name,
+            args: entry.args,
+            status: (entry.output ? "done" : "running") as "done" | "running",
+            result: entry.output,
+          },
+        },
+      });
+    }
+  }
+
+  // Sort by timestamp to preserve interleave order
+  items.sort((a, b) => a.ts - b.ts);
+  for (const item of items) {
+    result.push(item.segment);
+  }
+
+  // Append current (uncommitted) chatStream text as trailing segment
+  const currentText = refs.chatStream.current;
+  if (currentText && currentText.trim()) {
+    result.push({ type: "text", text: currentText });
+  }
+
+  return result;
 }
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -104,6 +104,7 @@ export {
   type AgentStatus,
   type ToolStreamEntry,
   type ToolStreamRefs,
+  type MessageSegment,
 } from "./gateway/chat-stream-types";
 export {
   createToolStreamRefs,
@@ -112,6 +113,7 @@ export {
   hasActiveStream,
   buildStreamContent,
   buildStreamToolCalls,
+  buildStreamSegments,
 } from "./gateway/tool-stream";
 export {
   HIDDEN_REPLY_RE,


### PR DESCRIPTION
## Summary
Cmd+N으로 열린 새 창에서 세션을 변경한 뒤 Cmd+R로 새로고침하면, 최초 세션으로 복귀되는 버그 수정.

Closes #256

## Root Cause
Electron 메뉴의 `{ role: "reload" }`가 최초 `loadURL/loadFile`에 전달된 `?session=...` query param을 그대로 다시 로드함.
렌더러에서 `updateSessionKey` IPC로 main의 `windowSessionKeys`를 갱신하지만, reload 시 이 값을 참조하지 않았음.

## Changes
- `window-reload.ts`: `buildReloadTarget()` 순수 함수 추출 — windowSessionKeys에서 최신 sessionKey를 읽어 URL/file 타겟 구성
- `index.ts`: 메뉴 `{ role: "reload" }` / `{ role: "forceReload" }`를 커스텀 핸들러로 교체
- `index.ts`: `render-process-gone` 핸들러도 `reloadWindow()` 적용
- 7개 테스트 추가 (dev/prod 모드, 세션 변경 시나리오, edge cases)

## Test
- `vitest run`: 82 passed (기존 81 + 신규 7, 기존 1 failed 무관)
- `electron-vite build`: 성공
- 실 테스트: Cmd+N → 세션 변경 → Cmd+R → 변경된 세션 유지 확인 ✅