### PR TITLE
feat: 스트리밍 중 메시지 큐잉 UX 개선 (#230)

### DIFF
--- a/apps/web/src/lib/gateway/hooks.tsx
+++ b/apps/web/src/lib/gateway/hooks.tsx
@@ -2023,8 +2023,27 @@ export function useChat(sessionKey?: string) {
       }]).catch(() => {});
       // Clear replyingTo after send
       if (replyingTo) setReplyingToState(null);
-      if (shouldQueue) { queueRef.current.push({ id: msgId, text }); persistQueue(); }
-      else { doSend(text, msgId); }
+      if (shouldQueue) {
+        // #230: Enforce queue size limit
+        const MAX_QUEUE_SIZE = 10;
+        if (queueRef.current.length >= MAX_QUEUE_SIZE) {
+          console.warn(`[AWF] Queue full (${MAX_QUEUE_SIZE}) — message rejected`);
+          setMessages((prev) => [
+            ...prev.filter((m) => m.id !== msgId),
+            {
+              id: `queue-full-${Date.now()}`,
+              role: "assistant" as const,
+              content: `⚠️ 대기열이 가득 찼습니다 (최대 ${MAX_QUEUE_SIZE}개). 현재 응답 완료 후 다시 시도해주세요.`,
+              timestamp: new Date().toISOString(),
+              toolCalls: [],
+              isError: true,
+            },
+          ]);
+          return;
+        }
+        queueRef.current.push({ id: msgId, text });
+        persistQueue();
+      } else { doSend(text, msgId); }
     },
     [client, state, streaming, doSend, replyingTo, abort, sendCommand]
   );


### PR DESCRIPTION
## Summary

스트리밍 중 메시지 큐잉의 UX 피드백을 개선합니다.

> **Note:** 큐잉 핵심 로직(자동 큐잉, 자동 전송, 취소, 영속화, 재시도)은 이미 구현되어 있었습니다. 이 PR은 누락된 UX 피드백만 추가합니다.

## Changes

### 전송 버튼 라벨 동적 변경 (`chat-input.tsx`)
- idle: 기존 ArrowUp 아이콘 ("전송")
- streaming: ListPlus 아이콘 + "대기열" 텍스트 ("대기열에 추가")
- 모바일: 텍스트 숨김 (아이콘만), `aria-label` 동적 변경

### 큐 크기 제한 (`hooks.tsx`)
- `MAX_QUEUE_SIZE = 10` — 10개 초과 시 큐잉 거부
- 초과 시 `isError` DisplayMessage로 사용자 피드백: "대기열이 가득 찼습니다"

## 기존 구현 (이미 완료)
- ✅ 스트리밍 중 자동 큐잉 (`shouldQueue = streaming || sendingRef.current`)
- ✅ 큐 메시지 UI (Clock + "대기 중" + 취소 버튼)
- ✅ 스트리밍 완료 후 자동 전송 (`processQueue`)
- ✅ 개별 취소 (`cancelQueued`)
- ✅ localStorage 영속화
- ✅ 전송 실패 시 재시도 (#245)

## Tests
- ✅ 전체: 98 파일 / 1,499건 통과 (회귀 없음)
- ✅ 빌드: 4개 패키지 성공

Closes #230