### PR TITLE
fix: prevent horizontal overflow in message bubbles

### DIFF
--- a/apps/web/src/components/chat/markdown-renderer.tsx
+++ b/apps/web/src/components/chat/markdown-renderer.tsx
@@ -700,7 +700,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   // Collapse 3+ consecutive newlines to 2 (one blank line)
   const cleaned = withoutMedia.replace(/\n{3,}/g, "\n\n").trim();
   return (
-    <div className="prose">
+    <div className="prose min-w-0 overflow-hidden">
       {mediaEntries.length > 0 && (
         <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-thin">
           {mediaEntries.map((entry, i) => (

--- a/apps/web/src/components/chat/message-list.tsx
+++ b/apps/web/src/components/chat/message-list.tsx
@@ -864,10 +864,10 @@ const MessageBubble = React.memo(React.forwardRef<HTMLDivElement, { message: Dis
       )}
 
       <div
-        className={`min-w-0 max-w-[90%] md:max-w-[85%] ${
+        className={`min-w-0 max-w-[90%] md:max-w-[85%] overflow-hidden ${
           isUser
             ? `rounded-2xl rounded-br-md px-3.5 py-2 md:px-4 md:py-2.5 text-foreground ${isQueued ? "bg-primary/15 border border-primary/20" : "bg-primary/15 border border-primary/10"}${selected ? " outline outline-2 outline-amber-500 bg-amber-500/10" : focused ? " outline outline-2 outline-amber-500/50" : ""}`
-            : `rounded-2xl rounded-bl-md px-3.5 py-2 md:px-4 md:py-2.5 bg-zinc-800/60 border border-zinc-700/50 flex-1${selected ? " outline outline-2 outline-amber-500 bg-amber-500/10" : focused ? " outline outline-2 outline-amber-500/50" : ""}`
+            : `rounded-2xl rounded-bl-md px-3.5 py-2 md:px-4 md:py-2.5 bg-zinc-800/60 border border-zinc-700/50${selected ? " outline outline-2 outline-amber-500 bg-amber-500/10" : focused ? " outline outline-2 outline-amber-500/50" : ""}`
         }`}
       >
         {isUser ? (


### PR DESCRIPTION
## 증상
Electron에서 메시지 버블이 가로로 넘쳐 레이아웃이 깨지는 현상.

## Root Cause
1. 메시지 버블 컨테이너에 `overflow-hidden`이 없어 내부 콘텐츠(코드 블록, 긴 URL)가 `max-w-[90%]`를 초과하여 렌더링
2. 어시스턴트 버블에 `flex-1`이 있어 부모 flex 컨테이너에서 무제한 가로 확장 허용
3. `MarkdownRenderer`의 최상위 `prose` div에 overflow 제한 없음

## Changes
- **`message-list.tsx`**: 버블 컨테이너에 `overflow-hidden` 추가, 어시스턴트 버블에서 `flex-1` 제거
- **`markdown-renderer.tsx`**: prose div에 `min-w-0 overflow-hidden` 추가

## 영향 범위
CSS만 변경, 로직 변경 없음. 2파일 3줄 수정.