### PR TITLE
chore: CI cleanup + #321/#322 follow-up nits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,24 +36,47 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          ISSUES=""
+          CANDIDATE_ISSUES=""
 
-          # From branch name
+          # From branch name (e.g. fix/123-foo, feat/45-bar)
+          # The number is treated as a HINT — we validate it below before
+          # blocking on assignees, because branch names sometimes encode
+          # PR numbers, milestones, or non-issue identifiers.
           if [[ "$PR_BRANCH" =~ ^(fix|feat|refactor|chore|docs)/([0-9]+) ]]; then
-            ISSUES="${BASH_REMATCH[2]}"
+            CANDIDATE_ISSUES="${BASH_REMATCH[2]}"
           fi
 
-          # From PR body
+          # From PR body — closing keywords like "fixes #123"
           BODY=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json body -q '.body')
           BODY_ISSUES=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#([0-9]+)' | grep -oE '[0-9]+' || true)
           for i in $BODY_ISSUES; do
-            if [[ ! " $ISSUES " =~ " $i " ]]; then
+            if [[ ! " $CANDIDATE_ISSUES " =~ " $i " ]]; then
+              CANDIDATE_ISSUES="$CANDIDATE_ISSUES $i"
+            fi
+          done
+
+          if [ -z "$CANDIDATE_ISSUES" ]; then
+            echo "::warning::No linked issue found. Consider linking an issue."
+            exit 0
+          fi
+
+          # Validate each candidate is an actual GitHub issue (not a PR
+          # number or stale reference). Non-existent / non-issue references
+          # degrade to a warning instead of failing the workflow.
+          # Without this guard, branches named after PR numbers or
+          # milestones (e.g. fix/322-perf-cleanup) crash `gh issue view`
+          # with "Could not resolve to an issue or pull request" → exit 1.
+          ISSUES=""
+          for i in $CANDIDATE_ISSUES; do
+            if gh issue view "$i" --repo "$GITHUB_REPOSITORY" --json number -q '.number' > /dev/null 2>&1; then
               ISSUES="$ISSUES $i"
+            else
+              echo "::warning::Reference #$i (from branch or PR body) is not a valid issue — ignoring."
             fi
           done
 
           if [ -z "$ISSUES" ]; then
-            echo "::warning::No linked issue found. Consider linking an issue."
+            echo "::warning::No valid linked issue found. Consider linking an issue."
             exit 0
           fi
 

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -18,11 +18,22 @@ jobs:
     steps:
       - name: Extract issue number from branch name
         id: extract
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="${GITHUB_REF#refs/heads/}"
-          # Match fix/142-*, feat/79-*, etc.
+          # Match fix/142-*, feat/79-*, etc. The number is treated as a HINT
+          # — validate it points to a real issue before emitting, otherwise
+          # downstream `gh issue edit` crashes the workflow on branches that
+          # encode PR numbers, milestones, or non-issue identifiers.
           if [[ "$BRANCH" =~ ^(fix|feat|refactor|chore|docs)/([0-9]+) ]]; then
-            echo "issue=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+            CANDIDATE="${BASH_REMATCH[2]}"
+            if gh issue view "$CANDIDATE" --repo "$GITHUB_REPOSITORY" --json number -q '.number' > /dev/null 2>&1; then
+              echo "issue=$CANDIDATE" >> "$GITHUB_OUTPUT"
+            else
+              echo "::warning::Branch references #$CANDIDATE but no such issue exists — skipping auto-assign."
+              echo "issue=" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "issue=" >> "$GITHUB_OUTPUT"
           fi
@@ -60,9 +71,9 @@ jobs:
         run: |
           # From branch name
           BRANCH="${{ github.event.pull_request.head.ref }}"
-          ISSUES=""
+          CANDIDATES=""
           if [[ "$BRANCH" =~ ^(fix|feat|refactor|chore|docs)/([0-9]+) ]]; then
-            ISSUES="${BASH_REMATCH[2]}"
+            CANDIDATES="${BASH_REMATCH[2]}"
           fi
 
           # From PR body (Closes #N, Fixes #N, Resolves #N)
@@ -70,8 +81,20 @@ jobs:
           BODY_ISSUES=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#([0-9]+)' | grep -oE '[0-9]+' || true)
 
           for i in $BODY_ISSUES; do
-            if [[ ! " $ISSUES " =~ " $i " ]]; then
+            if [[ ! " $CANDIDATES " =~ " $i " ]]; then
+              CANDIDATES="$CANDIDATES $i"
+            fi
+          done
+
+          # Validate each candidate is a real issue. Skip references that
+          # collide with PR numbers / milestones / nonexistent issues so the
+          # downstream `gh issue edit` doesn't crash with set -e.
+          ISSUES=""
+          for i in $CANDIDATES; do
+            if gh issue view "$i" --repo "$GITHUB_REPOSITORY" --json number -q '.number' > /dev/null 2>&1; then
               ISSUES="$ISSUES $i"
+            else
+              echo "::warning::Reference #$i is not a valid issue — skipping label transition."
             fi
           done
 
@@ -105,17 +128,27 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           BRANCH="${{ github.event.pull_request.head.ref }}"
-          ISSUES=""
+          CANDIDATES=""
           if [[ "$BRANCH" =~ ^(fix|feat|refactor|chore|docs)/([0-9]+) ]]; then
-            ISSUES="${BASH_REMATCH[2]}"
+            CANDIDATES="${BASH_REMATCH[2]}"
           fi
 
           BODY=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json body -q '.body')
           BODY_ISSUES=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#([0-9]+)' | grep -oE '[0-9]+' || true)
 
           for i in $BODY_ISSUES; do
-            if [[ ! " $ISSUES " =~ " $i " ]]; then
+            if [[ ! " $CANDIDATES " =~ " $i " ]]; then
+              CANDIDATES="$CANDIDATES $i"
+            fi
+          done
+
+          # Validate each candidate is a real issue (same guard as on-pr-opened).
+          ISSUES=""
+          for i in $CANDIDATES; do
+            if gh issue view "$i" --repo "$GITHUB_REPOSITORY" --json number -q '.number' > /dev/null 2>&1; then
               ISSUES="$ISSUES $i"
+            else
+              echo "::warning::Reference #$i is not a valid issue — skipping label cleanup."
             fi
           done
 

--- a/apps/web/src/components/chat/chat-header.tsx
+++ b/apps/web/src/components/chat/chat-header.tsx
@@ -157,22 +157,24 @@ export function ChatHeader({
   const agentId = parsed?.agentId;
   const allAgentSessions = useMemo(() => {
     if (!agentId) return [];
+    // Type predicate narrows `SessionEntry` (key?: string) to `key: string`
+    // so the dedup helper picks up the exact element type without casts.
     const filtered = sessions
-      .filter((s) => {
+      .filter((s): s is SessionEntry & { key: string } => {
         if (!s.key) return false;
-        const p = parseSessionKey(s.key as string);
+        const p = parseSessionKey(s.key);
         if (p.agentId !== agentId) return false;
         if (p.type !== "main" && p.type !== "thread") return false;
         // Hide hidden sessions from tabs (main is always visible)
-        if (p.type !== "main" && isSessionHidden(s.key as string)) return false;
+        if (p.type !== "main" && isSessionHidden(s.key)) return false;
         // Hide closed topics from tab bar
         if (s.label && typeof s.label === "string" && isTopicClosed({ label: s.label })) return false;
         return true;
       })
       .sort((a, b) => {
         // Main always first
-        const aType = parseSessionKey((a.key || "") as string).type;
-        const bType = parseSessionKey((b.key || "") as string).type;
+        const aType = parseSessionKey(a.key).type;
+        const bType = parseSessionKey(b.key).type;
         if (aType === "main" && bType !== "main") return -1;
         if (bType === "main" && aType !== "main") return 1;
         const aTime = typeof (a as any).updatedAt === "string" ? new Date((a as any).updatedAt).getTime() : ((a as any).updatedAt || 0);
@@ -187,7 +189,7 @@ export function ChatHeader({
     //   because closing one of 64 visible siblings did nothing perceptible.
     //   Sort above is updatedAt desc, so the first occurrence per
     //   conversation wins (most recent stays visible).
-    return dedupeChannelConversations(filtered as Array<{ key: string }>) as typeof filtered;
+    return dedupeChannelConversations(filtered);
   }, [sessions, agentId]);
 
   // Show all sessions (no active/idle split)

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -816,7 +816,7 @@ export function ChatPanel({ showHeader = true }: ChatPanelProps) {
     upsertSession(newKey, {
       label,
       updatedAt: Date.now(),
-    } as Partial<GatewaySession>);
+    });
     setSessionKey(newKey);
     refocusPanel();
 

--- a/apps/web/src/lib/gateway/hooks.tsx
+++ b/apps/web/src/lib/gateway/hooks.tsx
@@ -673,13 +673,18 @@ export function useSessions() {
   }, []);
 
   /**
-   * #322: Optimistically insert a session into local state so a brand-new
-   * tab (Cmd+T new topic) appears instantly without waiting for the next
-   * `sessions.list` round-trip. The next polling refresh reconciles with
-   * gateway truth — if the gateway didn't accept the create, the entry is
-   * silently removed on reconcile.
+   * #322: Optimistically insert (or update) a session in local state so a
+   * brand-new tab (Cmd+T new topic) appears instantly without waiting for
+   * the next `sessions.list` round-trip. The next polling refresh
+   * reconciles with gateway truth — if the gateway didn't accept the
+   * create, the entry is silently removed on reconcile.
+   *
+   * Signature mirrors `patchSession` (Record<string, unknown>) so callers
+   * can pass arbitrary gateway fields like `label` / numeric `updatedAt`
+   * that aren't on the narrow `Session` shape but DO live on the runtime
+   * objects (see fetchSessions where the spread retains all gateway data).
    */
-  const upsertSession = useCallback((key: string, partial: Partial<Session>) => {
+  const upsertSession = useCallback((key: string, partial: Record<string, unknown>) => {
     setSessions((prev) => {
       const idx = prev.findIndex((s) => s.key === key);
       if (idx === -1) {

--- a/packages/shared/src/gateway/chat-stream-processor.ts
+++ b/packages/shared/src/gateway/chat-stream-processor.ts
@@ -424,9 +424,20 @@ export class ChatStreamProcessor {
     } else if (stream === "lifecycle" && data?.phase === "start") {
       this.handleLifecycleStart(raw, data);
     } else if (stream === "lifecycle" && data?.phase === "end") {
-      // NO-OP for stream finalization — chat "final" handles it.
-      // Only record finalized event key for dedup.
+      // #225: lifecycle.end is ground truth that the run is over. Clear
+      // runId so it doesn't leak when the chat "final" event never arrives
+      // (subscription drop, gateway restart, error path, agent-only flows).
+      // chat "final" still calls finalizeActiveStream() which is idempotent
+      // for runId, so this is safe alongside the chat-event flow.
+      // Only clear if the event's runId matches ours (or is absent), to
+      // avoid clearing on stale events from a previous run.
       const eventRunId = resolveRunId(raw, data);
+      if (!eventRunId || eventRunId === this.runId) {
+        if (this.runId !== null) {
+          this.runId = null;
+          this.cb.onRunIdChange(null);
+        }
+      }
       const key = finalEventKey(eventRunId);
       if (key) this.finalizedEventKeys.add(key);
     } else if (
@@ -434,8 +445,16 @@ export class ChatStreamProcessor {
       stream === "end" ||
       stream === "finish"
     ) {
-      // NO-OP — same as lifecycle.end. Only record dedup key.
+      // #225: same as lifecycle.end — these are explicit stream-termination
+      // signals. Clear runId so subsequent chat.abort fallback logic uses
+      // sessionKey-only (no stale runId).
       const eventRunId = resolveRunId(raw, data);
+      if (!eventRunId || eventRunId === this.runId) {
+        if (this.runId !== null) {
+          this.runId = null;
+          this.cb.onRunIdChange(null);
+        }
+      }
       const key = finalEventKey(eventRunId);
       if (key) this.finalizedEventKeys.add(key);
     } else if (stream === "error") {

--- a/packages/shared/src/gateway/session-utils.ts
+++ b/packages/shared/src/gateway/session-utils.ts
@@ -215,7 +215,10 @@ export function isTopicSession(key: string): boolean {
  */
 function isPerMessageDummyThread(key: string): boolean {
   const parts = key.split(":");
-  const ti = parts.indexOf("thread");
+  // Use the LAST `:thread:` segment so nested keys (theoretical, not seen
+  // in OpenClaw today) collapse correctly: only the trailing thread group
+  // matters for "is this a per-message dummy" — outer threads are real.
+  const ti = parts.lastIndexOf("thread");
   if (ti < 0 || ti < 4) return false; // need at least `agent:{id}:{ch}:{kind}:{chatId}:thread:...`
   const parentChatId = parts[ti - 1]; // segment immediately before `:thread:`
   const firstThreadSeg = parts[ti + 1];


### PR DESCRIPTION
## Summary

Three small follow-ups, kept in one PR because they share CI as the verification path.

### CI cleanup (the noisy half)
The CI checks on PR #321 were red for two unrelated reasons. Both fixed here:

1. **`ci.yml issue-check`** — extracted `322` from `fix/322-cmdt-d-perf-...` branch name, called `gh issue view 322`, the issue didn't exist, `set -e` aborted the workflow. Now validates each candidate ref against the GH issues API and degrades non-issues to warnings.
2. **`issue-tracker.yml on-branch-push / on-pr-opened / on-pr-merged`** — same root cause in three more places. Same validation guard added so auto-assign + label transitions skip bogus refs without aborting.

### #225 follow-up — runId leak in shared processor
Pre-existing failure: 5/47 mobile `chatStateManager-runid.test.ts` tests have been red on `main` since the #254 streaming-core refactor extracted the per-platform processor into `packages/shared`. The refactor turned `lifecycle.end` and `done`/`end`/`finish` agent events into NO-OPs with the comment *"chat 'final' handles it"* — but chat final isn't always sent (subscription drop, error path, agent-only flows), and `finalizeActiveStream`'s early-return path doesn't clear runId either, so it leaked.

**Fix** (`chat-stream-processor.ts`): restore the original #225 intent so `lifecycle.end` and `done`/`end`/`finish` clear runId. Includes a matching-runId guard so stale lifecycle events from a previous run don't clobber the current one. Web's chat-final flow remains the canonical path; this just adds the agent-event safety net.

### #321/#322 nits (the small half)
Three follow-up cleanups from the PR #321 review:

- **`chat-header.tsx`**: type-predicate filter (`s is SessionEntry & { key: string }`) narrows `SessionEntry` so `dedupeChannelConversations<T>` picks up the exact element type without the `as Array<{ key: string }>` / `as typeof filtered` double cast.
- **`hooks.tsx upsertSession`**: signature mirrors `patchSession` (`Record<string, unknown>`) so callers can pass arbitrary gateway fields like `label` / numeric `updatedAt` that aren't on the narrow `Session` shape.
- **`chat-panel.tsx createSessionForAgent`**: dropped the now-redundant `as Partial<GatewaySession>` cast.
- **`session-utils.ts isPerMessageDummyThread`**: switched `indexOf` → `lastIndexOf` so theoretical nested-thread keys (not in OpenClaw today, but defensive) collapse on the trailing thread group.

## Test plan
- [x] `pnpm test` — all 5 turbo tasks green
  - server: 1 file / 19 tests
  - mobile: 4 files / **47/47** (was 42/47 before — the 5 #225 failures are now passing)
  - web: 118 files / 1676 tests
- [x] No new tests required for the workflow changes (CI itself will verify on this PR run)
- [x] No regressions in `issue-225-abort-with-runid` web test (lifecycle.end → runId clear path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)