### PR TITLE
feat: Channel Plugin 세션 히스토리 API — 재접속 시 이전 대화 복구

### DIFF
--- a/packages/shared/src/channel/client.ts
+++ b/packages/shared/src/channel/client.ts
@@ -139,7 +139,7 @@ export class ChannelClient {
     cwd?: string,
     limit?: number,
   ): Promise<SessionHistoryResponse> {
-    const target = new URL(`/sessions/${uuid}/history`, this.config.url);
+    const target = new URL(`/sessions/${encodeURIComponent(uuid)}/history`, this.config.url);
     if (cwd) target.searchParams.set("cwd", cwd);
     if (limit) target.searchParams.set("limit", String(limit));
     const res = await fetch(target, { headers: this.authHeaders() });

--- a/packages/shared/src/channel/client.ts
+++ b/packages/shared/src/channel/client.ts
@@ -12,6 +12,7 @@ import {
   type ChannelWire,
   type ConnectionState,
   type SendPayload,
+  type SessionHistoryResponse,
   type SessionListResponse,
   type UploadPayload,
 } from "./protocol";
@@ -131,6 +132,21 @@ export class ChannelClient {
     const res = await fetch(target, { headers: this.authHeaders() });
     if (!res.ok) throw new Error(`channel /sessions ${res.status}`);
     return (await res.json()) as SessionListResponse;
+  }
+
+  async loadSessionHistory(
+    uuid: string,
+    cwd?: string,
+    limit?: number,
+  ): Promise<SessionHistoryResponse> {
+    const target = new URL(`/sessions/${uuid}/history`, this.config.url);
+    if (cwd) target.searchParams.set("cwd", cwd);
+    if (limit) target.searchParams.set("limit", String(limit));
+    const res = await fetch(target, { headers: this.authHeaders() });
+    if (!res.ok) {
+      throw new Error(`channel /sessions/${uuid}/history ${res.status}`);
+    }
+    return (await res.json()) as SessionHistoryResponse;
   }
 
   async send(payload: SendPayload): Promise<void> {

--- a/packages/shared/src/channel/hooks.tsx
+++ b/packages/shared/src/channel/hooks.tsx
@@ -236,12 +236,42 @@ export function ChannelProvider({
 
     void c
       .fetchInfo()
-      .then((info) => {
+      .then(async (info) => {
         // Only adopt the plugin-reported active session if we have no local
         // preference yet. Saved sessions win to avoid surprising the user on
         // reload.
         if (!storageRef.current?.getItem(CHANNEL_SESSION_STORAGE_KEY)) {
           setActiveSessionIdState(info.activeSessionId);
+        }
+        // Load session history from JSONL (source of truth)
+        const activeUuid = info.activeSessionId;
+        if (activeUuid) {
+          try {
+            const history = await c.loadSessionHistory(activeUuid);
+            if (history.messages.length > 0) {
+              const restored: ChannelMsg[] = history.messages.map((m) => ({
+                id: m.id,
+                from: m.from,
+                text: m.text,
+                ts: m.ts,
+                sessionId: m.sessionId,
+              }));
+              setMessages((prev) => {
+                // Merge: JSONL history is source of truth, append any newer WS messages
+                const historyIds = new Set(restored.map((m) => m.id));
+                const newer = prev.filter(
+                  (m) =>
+                    !historyIds.has(m.id) &&
+                    m.ts > (restored[restored.length - 1]?.ts ?? 0),
+                );
+                const merged = [...restored, ...newer];
+                persistMessages(storageRef.current, merged);
+                return merged;
+              });
+            }
+          } catch {
+            // History API unavailable — fall back to localStorage (already loaded)
+          }
         }
       })
       .catch(() => {});

--- a/packages/shared/src/channel/hooks.tsx
+++ b/packages/shared/src/channel/hooks.tsx
@@ -225,8 +225,10 @@ export function ChannelProvider({
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
     const c = new ChannelClient(configRef.current);
     const unsubState = c.onStateChange((s, err) => {
+      if (cancelled) return;
       setState(s);
       setError(err ?? null);
     });
@@ -237,6 +239,7 @@ export function ChannelProvider({
     void c
       .fetchInfo()
       .then(async (info) => {
+        if (cancelled) return;
         // Only adopt the plugin-reported active session if we have no local
         // preference yet. Saved sessions win to avoid surprising the user on
         // reload.
@@ -248,6 +251,7 @@ export function ChannelProvider({
         if (activeUuid) {
           try {
             const history = await c.loadSessionHistory(activeUuid);
+            if (cancelled) return;
             if (history.messages.length > 0) {
               const restored: ChannelMsg[] = history.messages.map((m) => ({
                 id: m.id,
@@ -277,6 +281,7 @@ export function ChannelProvider({
       .catch(() => {});
 
     return () => {
+      cancelled = true;
       unsubState();
       unsubMsg();
       c.disconnect();

--- a/packages/shared/src/channel/protocol.ts
+++ b/packages/shared/src/channel/protocol.ts
@@ -85,6 +85,7 @@ export interface SessionHistoryResponse {
   uuid: string;
   cwd: string;
   messages: SessionHistoryMsg[];
+  /** Total valid messages in the JSONL file (before limit is applied). */
   total: number;
 }
 

--- a/packages/shared/src/channel/protocol.ts
+++ b/packages/shared/src/channel/protocol.ts
@@ -73,6 +73,21 @@ export interface SessionListResponse {
   sessions: ClaudeSessionSummary[];
 }
 
+export interface SessionHistoryMsg {
+  id: string;
+  from: "user" | "assistant";
+  text: string;
+  ts: number;
+  sessionId: string;
+}
+
+export interface SessionHistoryResponse {
+  uuid: string;
+  cwd: string;
+  messages: SessionHistoryMsg[];
+  total: number;
+}
+
 export interface SendPayload {
   id: string;
   text: string;

--- a/plugins/intelli-claw-channel/server.test.ts
+++ b/plugins/intelli-claw-channel/server.test.ts
@@ -490,12 +490,20 @@ describe("parseSessionHistory", () => {
       { type: "user", userType: "external", message: { content: "hello" }, uuid: "u1", timestamp: "2025-01-01T00:00:00Z" },
       { type: "assistant", message: { content: "hi there" }, uuid: "a1", timestamp: "2025-01-01T00:00:01Z" },
     ]);
-    const msgs = parseSessionHistory(path);
-    expect(msgs).toHaveLength(2);
-    expect(msgs[0].from).toBe("user");
-    expect(msgs[0].text).toBe("hello");
-    expect(msgs[1].from).toBe("assistant");
-    expect(msgs[1].text).toBe("hi there");
+    const result = parseSessionHistory(path);
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0].from).toBe("user");
+    expect(result.messages[0].text).toBe("hello");
+    expect(result.messages[1].from).toBe("assistant");
+    expect(result.messages[1].text).toBe("hi there");
+  });
+
+  it("uses provided sessionId", () => {
+    const path = writeJsonl("test.jsonl", [
+      { type: "user", userType: "external", message: { content: "hello" }, uuid: "u1" },
+    ]);
+    const result = parseSessionHistory(path, "my-session");
+    expect(result.messages[0].sessionId).toBe("my-session");
   });
 
   it("filters non-external userType", () => {
@@ -503,9 +511,9 @@ describe("parseSessionHistory", () => {
       { type: "user", userType: "internal", message: { content: "system msg" }, uuid: "u1" },
       { type: "user", userType: "external", message: { content: "real msg" }, uuid: "u2" },
     ]);
-    const msgs = parseSessionHistory(path);
-    expect(msgs).toHaveLength(1);
-    expect(msgs[0].text).toBe("real msg");
+    const result = parseSessionHistory(path);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe("real msg");
   });
 
   it("filters hook injections", () => {
@@ -513,9 +521,9 @@ describe("parseSessionHistory", () => {
       { type: "user", userType: "external", message: { content: "<system-reminder>injected" }, uuid: "u1" },
       { type: "user", userType: "external", message: { content: "normal message" }, uuid: "u2" },
     ]);
-    const msgs = parseSessionHistory(path);
-    expect(msgs).toHaveLength(1);
-    expect(msgs[0].text).toBe("normal message");
+    const result = parseSessionHistory(path);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe("normal message");
   });
 
   it("respects limit parameter", () => {
@@ -527,9 +535,26 @@ describe("parseSessionHistory", () => {
       timestamp: `2025-01-01T00:00:${String(i).padStart(2, "0")}Z`,
     }));
     const path = writeJsonl("test.jsonl", entries);
-    const msgs = parseSessionHistory(path, 3);
-    expect(msgs).toHaveLength(3);
-    expect(msgs[0].text).toBe("msg 7"); // last 3
+    const result = parseSessionHistory(path, "main", 3);
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[0].text).toBe("msg 7"); // last 3
+    expect(result.totalBeforeLimit).toBe(10);
+  });
+
+  it("clamps invalid limit to default 400", () => {
+    const entries = Array.from({ length: 5 }, (_, i) => ({
+      type: "user",
+      userType: "external",
+      message: { content: `msg ${i}` },
+      uuid: `u${i}`,
+    }));
+    const path = writeJsonl("test.jsonl", entries);
+    const r1 = parseSessionHistory(path, "main", NaN);
+    expect(r1.messages).toHaveLength(5); // all fit within default 400
+    const r2 = parseSessionHistory(path, "main", -1);
+    expect(r2.messages).toHaveLength(5);
+    const r3 = parseSessionHistory(path, "main", 0);
+    expect(r3.messages).toHaveLength(5);
   });
 
   it("handles malformed JSONL lines gracefully", () => {
@@ -538,22 +563,23 @@ describe("parseSessionHistory", () => {
       path,
       '{"type":"user","userType":"external","message":{"content":"ok"},"uuid":"u1"}\nnot json\n{"type":"assistant","message":{"content":"reply"},"uuid":"a1"}',
     );
-    const msgs = parseSessionHistory(path);
-    expect(msgs).toHaveLength(2);
+    const result = parseSessionHistory(path);
+    expect(result.messages).toHaveLength(2);
   });
 
-  it("returns empty array for missing file", () => {
-    const msgs = parseSessionHistory("/nonexistent/path.jsonl");
-    expect(msgs).toHaveLength(0);
+  it("returns empty for missing file", () => {
+    const result = parseSessionHistory("/nonexistent/path.jsonl");
+    expect(result.messages).toHaveLength(0);
+    expect(result.totalBeforeLimit).toBe(0);
   });
 
   it("handles array content format", () => {
     const path = writeJsonl("test.jsonl", [
       { type: "assistant", message: { content: [{ type: "text", text: "part 1" }, { type: "text", text: "part 2" }] }, uuid: "a1" },
     ]);
-    const msgs = parseSessionHistory(path);
-    expect(msgs).toHaveLength(1);
-    expect(msgs[0].text).toBe("part 1\npart 2");
+    const result = parseSessionHistory(path);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe("part 1\npart 2");
   });
 });
 
@@ -572,8 +598,20 @@ describe("HTTP /sessions/:uuid/history", () => {
     server.stop(true);
   });
 
-  it("GET /sessions/:uuid/history returns 404 for missing session", async () => {
+  it("returns 404 for missing session", async () => {
     const res = await fetch(`${base}/sessions/nonexistent-uuid/history`);
     expect(res.status).toBe(404);
+  });
+
+  it("rejects uuid with path traversal", async () => {
+    const res = await fetch(`${base}/sessions/..%2f..%2fetc/history`);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects uuid with null byte", async () => {
+    const res = await fetch(`${base}/sessions/abc%00def/history`);
+    // URL parser strips null bytes before they reach the handler;
+    // the resulting uuid won't match any file → 404.
+    expect([400, 404]).toContain(res.status);
   });
 });

--- a/plugins/intelli-claw-channel/server.test.ts
+++ b/plugins/intelli-claw-channel/server.test.ts
@@ -22,6 +22,10 @@ import {
   pendingPermissions,
   resolvePermissionVerdict,
   isAuthorized,
+  extractText,
+  looksLikeHookInjection,
+  parseSessionHistory,
+  HIDDEN_PREFIXES,
 } from "./server";
 
 // ---------- mime ----------
@@ -414,5 +418,162 @@ describe("resolvePermissionVerdict", () => {
     });
     expect(resolvePermissionVerdict("abcde", "allow")).toBe(true);
     expect(resolvePermissionVerdict("abcde", "allow")).toBe(false);
+  });
+});
+
+// ---------- extractText ----------
+
+describe("extractText", () => {
+  it("returns string content as-is", () => {
+    expect(extractText("hello world")).toBe("hello world");
+  });
+
+  it("joins array content text parts", () => {
+    const content = [
+      { type: "text", text: "line 1" },
+      { type: "text", text: "line 2" },
+    ];
+    expect(extractText(content)).toBe("line 1\nline 2");
+  });
+
+  it("returns empty for non-text content", () => {
+    expect(extractText(42)).toBe("");
+    expect(extractText(null)).toBe("");
+    expect(extractText(undefined)).toBe("");
+  });
+
+  it("skips non-text array parts", () => {
+    const content = [
+      { type: "image", url: "..." },
+      { type: "text", text: "only this" },
+    ];
+    expect(extractText(content)).toBe("only this");
+  });
+});
+
+// ---------- looksLikeHookInjection ----------
+
+describe("looksLikeHookInjection", () => {
+  it("detects system markers", () => {
+    expect(looksLikeHookInjection("<system-reminder>some text")).toBe(true);
+    expect(looksLikeHookInjection("<bash-stdout>output")).toBe(true);
+    expect(looksLikeHookInjection("<user-prompt-submit-hook>...")).toBe(true);
+  });
+
+  it("passes normal text", () => {
+    expect(looksLikeHookInjection("hello world")).toBe(false);
+    expect(looksLikeHookInjection("fix the bug in server.ts")).toBe(false);
+  });
+});
+
+// ---------- parseSessionHistory ----------
+
+describe("parseSessionHistory", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "history-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeJsonl(filename: string, entries: unknown[]): string {
+    const path = join(tmpDir, filename);
+    writeFileSync(path, entries.map((e) => JSON.stringify(e)).join("\n"));
+    return path;
+  }
+
+  it("extracts user and assistant turns", () => {
+    const path = writeJsonl("test.jsonl", [
+      { type: "user", userType: "external", message: { content: "hello" }, uuid: "u1", timestamp: "2025-01-01T00:00:00Z" },
+      { type: "assistant", message: { content: "hi there" }, uuid: "a1", timestamp: "2025-01-01T00:00:01Z" },
+    ]);
+    const msgs = parseSessionHistory(path);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].from).toBe("user");
+    expect(msgs[0].text).toBe("hello");
+    expect(msgs[1].from).toBe("assistant");
+    expect(msgs[1].text).toBe("hi there");
+  });
+
+  it("filters non-external userType", () => {
+    const path = writeJsonl("test.jsonl", [
+      { type: "user", userType: "internal", message: { content: "system msg" }, uuid: "u1" },
+      { type: "user", userType: "external", message: { content: "real msg" }, uuid: "u2" },
+    ]);
+    const msgs = parseSessionHistory(path);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].text).toBe("real msg");
+  });
+
+  it("filters hook injections", () => {
+    const path = writeJsonl("test.jsonl", [
+      { type: "user", userType: "external", message: { content: "<system-reminder>injected" }, uuid: "u1" },
+      { type: "user", userType: "external", message: { content: "normal message" }, uuid: "u2" },
+    ]);
+    const msgs = parseSessionHistory(path);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].text).toBe("normal message");
+  });
+
+  it("respects limit parameter", () => {
+    const entries = Array.from({ length: 10 }, (_, i) => ({
+      type: "user",
+      userType: "external",
+      message: { content: `msg ${i}` },
+      uuid: `u${i}`,
+      timestamp: `2025-01-01T00:00:${String(i).padStart(2, "0")}Z`,
+    }));
+    const path = writeJsonl("test.jsonl", entries);
+    const msgs = parseSessionHistory(path, 3);
+    expect(msgs).toHaveLength(3);
+    expect(msgs[0].text).toBe("msg 7"); // last 3
+  });
+
+  it("handles malformed JSONL lines gracefully", () => {
+    const path = join(tmpDir, "bad.jsonl");
+    writeFileSync(
+      path,
+      '{"type":"user","userType":"external","message":{"content":"ok"},"uuid":"u1"}\nnot json\n{"type":"assistant","message":{"content":"reply"},"uuid":"a1"}',
+    );
+    const msgs = parseSessionHistory(path);
+    expect(msgs).toHaveLength(2);
+  });
+
+  it("returns empty array for missing file", () => {
+    const msgs = parseSessionHistory("/nonexistent/path.jsonl");
+    expect(msgs).toHaveLength(0);
+  });
+
+  it("handles array content format", () => {
+    const path = writeJsonl("test.jsonl", [
+      { type: "assistant", message: { content: [{ type: "text", text: "part 1" }, { type: "text", text: "part 2" }] }, uuid: "a1" },
+    ]);
+    const msgs = parseSessionHistory(path);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].text).toBe("part 1\npart 2");
+  });
+});
+
+// ---------- HTTP /sessions/:uuid/history ----------
+
+describe("HTTP /sessions/:uuid/history", () => {
+  let server: Awaited<ReturnType<typeof startHttpServer>>;
+  let base: string;
+
+  beforeEach(async () => {
+    server = await startHttpServer({ port: 0, hostname: "127.0.0.1" });
+    base = `http://127.0.0.1:${server.port}`;
+  });
+
+  afterEach(() => {
+    server.stop(true);
+  });
+
+  it("GET /sessions/:uuid/history returns 404 for missing session", async () => {
+    const res = await fetch(`${base}/sessions/nonexistent-uuid/history`);
+    expect(res.status).toBe(404);
   });
 });

--- a/plugins/intelli-claw-channel/server.ts
+++ b/plugins/intelli-claw-channel/server.ts
@@ -97,6 +97,89 @@ export interface SessionSummary {
   path: string;
 }
 
+// HIDDEN_PREFIXES — markers injected by hooks / system, not real user input.
+export const HIDDEN_PREFIXES = [
+  "<system-reminder>",
+  "<command-name>",
+  "<command-args>",
+  "<local-command-stdout>",
+  "<command-stdout>",
+  "<bash-stdout>",
+  "<bash-stderr>",
+  "<user-prompt-submit-hook>",
+];
+
+export function looksLikeHookInjection(text: string): boolean {
+  for (const prefix of HIDDEN_PREFIXES) {
+    if (text.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+export function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const p of content) {
+    if (!p || typeof p !== "object") continue;
+    const obj = p as { type?: string; text?: string };
+    if (obj.type === "text" && typeof obj.text === "string") parts.push(obj.text);
+  }
+  return parts.join("\n");
+}
+
+export interface HistoryMsg {
+  id: string;
+  from: "user" | "assistant";
+  text: string;
+  ts: number;
+  sessionId: string;
+}
+
+export function parseSessionHistory(
+  jsonlPath: string,
+  limit: number = 400,
+): HistoryMsg[] {
+  let raw: string;
+  try {
+    raw = readFileSync(jsonlPath, "utf8");
+  } catch {
+    return [];
+  }
+  const msgs: HistoryMsg[] = [];
+  const lines = raw.split("\n");
+  for (const line of lines) {
+    if (!line) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const type = entry.type as string | undefined;
+    const from: "user" | "assistant" | null =
+      type === "user" ? "user" : type === "assistant" ? "assistant" : null;
+    if (!from) continue;
+
+    if (from === "user") {
+      const userType = entry.userType as string | undefined;
+      if (userType && userType !== "external") continue;
+    }
+
+    const message = entry.message as Record<string, unknown> | undefined;
+    const text = extractText(message?.content ?? "").trim();
+    if (!text) continue;
+    if (looksLikeHookInjection(text)) continue;
+
+    const uuid = typeof entry.uuid === "string" ? entry.uuid : `hist-${msgs.length}`;
+    const timestamp = entry.timestamp as string | undefined;
+    const ts = timestamp ? Date.parse(timestamp) || Date.now() : Date.now();
+
+    msgs.push({ id: uuid, from, text, ts, sessionId: "main" });
+  }
+  return msgs.slice(-limit);
+}
+
 /**
  * Extract a human-readable preview from the first external user message in a
  * transcript. Tolerant to the variety of shapes Claude Code emits (string
@@ -680,6 +763,37 @@ export async function startHttpServer(
           {
             headers: { ...baseHeaders, "content-type": "application/json" },
           },
+        );
+      }
+
+      // GET /sessions/:uuid/history
+      const historyMatch = url.pathname.match(/^\/sessions\/([^/]+)\/history$/);
+      if (historyMatch && req.method === "GET") {
+        const uuid = historyMatch[1];
+        const queryCwd = url.searchParams.get("cwd") || "";
+        const envCwd = process.env.INTELLI_CLAW_PROJECT_CWD ?? "";
+        const cwd = queryCwd || envCwd || process.cwd();
+        const limit = parseInt(url.searchParams.get("limit") ?? "400", 10);
+
+        const jsonlPath = join(claudeProjectDir(cwd), `${uuid}.jsonl`);
+        try {
+          statSync(jsonlPath);
+        } catch {
+          return new Response(
+            JSON.stringify({ error: "session not found" }),
+            { status: 404, headers: { ...baseHeaders, "content-type": "application/json" } },
+          );
+        }
+
+        const messages = parseSessionHistory(jsonlPath, limit);
+        return new Response(
+          JSON.stringify({
+            uuid,
+            cwd,
+            messages,
+            total: messages.length,
+          }),
+          { headers: { ...baseHeaders, "content-type": "application/json" } },
         );
       }
 

--- a/plugins/intelli-claw-channel/server.ts
+++ b/plugins/intelli-claw-channel/server.ts
@@ -128,6 +128,7 @@ export function extractText(content: unknown): string {
   return parts.join("\n");
 }
 
+/** Matches SessionHistoryMsg in @intelli-claw/shared protocol.ts */
 export interface HistoryMsg {
   id: string;
   from: "user" | "assistant";
@@ -136,15 +137,24 @@ export interface HistoryMsg {
   sessionId: string;
 }
 
+export interface ParseHistoryResult {
+  messages: HistoryMsg[];
+  /** Total number of valid messages before limit is applied. */
+  totalBeforeLimit: number;
+}
+
 export function parseSessionHistory(
   jsonlPath: string,
+  sessionId: string = "main",
   limit: number = 400,
-): HistoryMsg[] {
+): ParseHistoryResult {
+  const safeLimit =
+    Number.isFinite(limit) && limit > 0 ? Math.min(limit, 2000) : 400;
   let raw: string;
   try {
     raw = readFileSync(jsonlPath, "utf8");
   } catch {
-    return [];
+    return { messages: [], totalBeforeLimit: 0 };
   }
   const msgs: HistoryMsg[] = [];
   const lines = raw.split("\n");
@@ -175,9 +185,9 @@ export function parseSessionHistory(
     const timestamp = entry.timestamp as string | undefined;
     const ts = timestamp ? Date.parse(timestamp) || Date.now() : Date.now();
 
-    msgs.push({ id: uuid, from, text, ts, sessionId: "main" });
+    msgs.push({ id: uuid, from, text, ts, sessionId });
   }
-  return msgs.slice(-limit);
+  return { messages: msgs.slice(-safeLimit), totalBeforeLimit: msgs.length };
 }
 
 /**
@@ -770,28 +780,34 @@ export async function startHttpServer(
       const historyMatch = url.pathname.match(/^\/sessions\/([^/]+)\/history$/);
       if (historyMatch && req.method === "GET") {
         const uuid = historyMatch[1];
+        // Path-traversal guard (mirrors /files/ handler)
+        if (!uuid || uuid.includes("..") || uuid.includes("/") || uuid.includes("\0")) {
+          return new Response("bad request", { status: 400, headers: baseHeaders });
+        }
         const queryCwd = url.searchParams.get("cwd") || "";
         const envCwd = process.env.INTELLI_CLAW_PROJECT_CWD ?? "";
         const cwd = queryCwd || envCwd || process.cwd();
-        const limit = parseInt(url.searchParams.get("limit") ?? "400", 10);
+        const rawLimit = parseInt(url.searchParams.get("limit") ?? "400", 10);
+        const limit =
+          Number.isFinite(rawLimit) && rawLimit > 0
+            ? Math.min(rawLimit, 2000)
+            : 400;
 
         const jsonlPath = join(claudeProjectDir(cwd), `${uuid}.jsonl`);
-        try {
-          statSync(jsonlPath);
-        } catch {
+        const result = parseSessionHistory(jsonlPath, uuid, limit);
+        if (result.totalBeforeLimit === 0) {
           return new Response(
             JSON.stringify({ error: "session not found" }),
             { status: 404, headers: { ...baseHeaders, "content-type": "application/json" } },
           );
         }
 
-        const messages = parseSessionHistory(jsonlPath, limit);
         return new Response(
           JSON.stringify({
             uuid,
             cwd,
-            messages,
-            total: messages.length,
+            messages: result.messages,
+            total: result.totalBeforeLimit,
           }),
           { headers: { ...baseHeaders, "content-type": "application/json" } },
         );


### PR DESCRIPTION
## Summary

- Channel Plugin에 `GET /sessions/:uuid/history` 엔드포인트 추가 — Claude Code JSONL 세션 파일을 파싱하여 전체 대화 내역 반환
- `ChannelClient.loadSessionHistory()` 메서드 추가
- `ChannelProvider` 연결 시 JSONL 히스토리 자동 로드 (localStorage 폴백 유지)
- 14개 유닛/통합 테스트 추가 (plugin 57 pass, web 20 pass)

## 변경 파일

| 파일 | 변경 |
|------|------|
| `plugins/intelli-claw-channel/server.ts` | `extractText()`, `looksLikeHookInjection()`, `parseSessionHistory()` + HTTP 엔드포인트 |
| `packages/shared/src/channel/protocol.ts` | `SessionHistoryMsg`, `SessionHistoryResponse` 타입 |
| `packages/shared/src/channel/client.ts` | `loadSessionHistory()` 메서드 |
| `packages/shared/src/channel/hooks.tsx` | Provider 연결 시 JSONL 히스토리 로드 + 병합 |
| `plugins/intelli-claw-channel/server.test.ts` | extractText 4, hookInjection 2, parseHistory 7, HTTP 1 |

## 동작 흐름

```
ChannelProvider mount
  → localStorage 캐시 로드 (빠른 초기 렌더)
  → WS 연결 + fetchInfo()
  → loadSessionHistory(activeUuid) 호출
  → JSONL 히스토리를 정본(source of truth)으로 메시지 교체
  → id 기준 중복 제거, 이후 새 메시지만 WS 수신
```

## Test plan

- [x] `extractText` — string/array/invalid 콘텐츠 처리
- [x] `looksLikeHookInjection` — 시스템 마커 감지 / 정상 텍스트 통과
- [x] `parseSessionHistory` — user/assistant 턴 추출, 시스템 메시지 필터, limit, malformed 라인, 배열 콘텐츠
- [x] `GET /sessions/:uuid/history` — 404 for missing session
- [ ] E2E: claude 기동 → 대화 → 브라우저 닫기 → 다시 열기 → 이전 대화 표시

Closes #324